### PR TITLE
qe_server: install pylatest

### DIFF
--- a/roles/qe-server-user/tasks/main.yml
+++ b/roles/qe-server-user/tasks/main.yml
@@ -24,6 +24,9 @@
      repo: "{{ tendrl_ansible_repo }}"
      version: "{{ tendrl_ansible_version }}"
 
+- name: HACK - install pylatest from PyPI via pip2
+  shell: pip2 install --user pylatest
+
 # Install all requirements of usmqe-tests repository via pip from PyPI
 # locally for usmqe user and rh-python35 software collection only.
 - name: HACK - install python modules required to run usmqe-tests

--- a/roles/qe-server/tasks/main.yml
+++ b/roles/qe-server/tasks/main.yml
@@ -127,6 +127,13 @@
 # other tools
 #
 
+- name: Install pylatest dependencies via yum
+  yum: name={{ item }} state=installed enablerepo=epel
+  with_items:
+   - python-pip
+   - python-lxml
+   - python-docutils
+
 - name: Install other dependencies and useful tools
   yum: name={{ item }} state=installed enablerepo=epel
   with_items:


### PR DESCRIPTION
Since pylatest requires more recent version of sphinx compared to what
is provided in el7, we install just python-lxml and python-docutils from
rpm packages and then under usmqe user account, install pylatest via pip
into ~/.local/lib/python2.7/ directory.