### PR TITLE
Fix gluster repository setup and package installation

### DIFF
--- a/gluster.yml
+++ b/gluster.yml
@@ -5,7 +5,8 @@
 - hosts: gluster
   remote_user: root
   vars:
-    install_from: packages
+    gluster_centos_repo: "nightly"
+    # gluster_centos_repo: "3-11" # for GlusterFS 3.11
   roles:
     - gluster-centos-repo
     - gluster-gdeploy-copr

--- a/gluster.yml
+++ b/gluster.yml
@@ -9,5 +9,5 @@
     # gluster_centos_repo: "3-11" # for GlusterFS 3.11
   roles:
     - gluster-centos-repo
-    - gluster-gdeploy-copr
+    # - gluster-gdeploy-copr
     - gluster-centos

--- a/roles/gluster-centos-repo/README.rst
+++ b/roles/gluster-centos-repo/README.rst
@@ -2,6 +2,30 @@
 Gluster-centos-repo
 ===================
 
-This role adds Gluster repo maintained by `CentOS Storage SIG`_.
+This role adds Gluster repo maintained by `CentOS Storage SIG`_. Note that
+packages installed by this role are not signed.
+
+The role is configured by variable ``gluster_centos_repo`` which could be
+eiter:
+
+* ``nightly``: Latest nightly builds from ``artifacts.ci.centos.org``.
+  When used, ``epel`` role is added into dependencies of this role so that
+  EPEL_ is installed and enabled as well (see explnanation below).
+* ``3-12``: GlusterFS version 3.12
+* ``3-11``: GlusterFS version 3.11
+* ``3-10``: GlusterFS version 3.10
+* ``3-9``: GlusterFS version 3.9
+
+Also note:
+
+* Nightly builds repo is the default.
+* You can't specify repo url directly, you need to select one release from the
+  list shown above.
+* It could happen that for nightly or rc builds, you would need to enable EPEL_
+  via ``epel`` role (eg. when you see error like ``Error: Package ...
+  Requires: liburcu-cds.so.6()(64bit)``, it means you are missing
+  `userspace-rcu`_).
 
 .. _`CentOS Storage SIG`: https://wiki.centos.org/SpecialInterestGroup/Storage
+.. _EPEL: https://fedoraproject.org/wiki/EPEL
+.. _`userspace-rcu`: https://apps.fedoraproject.org/packages/userspace-rcu

--- a/roles/gluster-centos-repo/README.rst
+++ b/roles/gluster-centos-repo/README.rst
@@ -2,4 +2,6 @@
 Gluster-centos-repo
 ===================
 
-This role adds Centos gluster repo.
+This role adds Gluster repo maintained by `CentOS Storage SIG`_.
+
+.. _`CentOS Storage SIG`: https://wiki.centos.org/SpecialInterestGroup/Storage

--- a/roles/gluster-centos-repo/defaults/main.yml
+++ b/roles/gluster-centos-repo/defaults/main.yml
@@ -1,2 +1,2 @@
 ---
-gluster_repo_url: "http://buildlogs.centos.org/centos/7/storage/x86_64/gluster-3.9"
+gluster_centos_repo: "nightly"

--- a/roles/gluster-centos-repo/meta/main.yml
+++ b/roles/gluster-centos-repo/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+  - {role: epel, epel_enabled: 1, when: gluster_centos_repo == "nightly" }

--- a/roles/gluster-centos-repo/tasks/main.yml
+++ b/roles/gluster-centos-repo/tasks/main.yml
@@ -3,7 +3,7 @@
 - name: Add Gluster yum repository
   yum_repository:
     name: gluster-centos
-    description: Gluster from CentOS Storage SIG
-    baseurl: "{{ gluster_repo_url }}"
+    description: "{{ gluster_centos_repos[gluster_centos_repo].description }}"
+    baseurl: "{{ gluster_centos_repos[gluster_centos_repo].baseurl }}"
     gpgcheck: no
     repo_gpgcheck: no

--- a/roles/gluster-centos-repo/tasks/main.yml
+++ b/roles/gluster-centos-repo/tasks/main.yml
@@ -5,3 +5,5 @@
     name: gluster-centos
     description: Gluster from CentOS Storage SIG
     baseurl: "{{ gluster_repo_url }}"
+    gpgcheck: no
+    repo_gpgcheck: no

--- a/roles/gluster-centos-repo/tasks/main.yml
+++ b/roles/gluster-centos-repo/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 
-- name: Add Gluster YUM repo
+- name: Add Gluster yum repository
   yum_repository:
-    name: gluster
-    description: Gluster YUM repo
+    name: gluster-centos
+    description: Gluster from CentOS Storage SIG
     baseurl: "{{ gluster_repo_url }}"

--- a/roles/gluster-centos-repo/vars/main.yml
+++ b/roles/gluster-centos-repo/vars/main.yml
@@ -1,0 +1,17 @@
+---
+gluster_centos_repos:
+    nightly:
+        description: "Gluster nightly builds from CentOS Storage SIG"
+        baseurl: "http://artifacts.ci.centos.org/gluster/nightly/master/7/x86_64/"
+    3-12:
+        description: "Gluster 3.12 from CentOS Storage SIG"
+        baseurl: "http://buildlogs.centos.org/centos/7/storage/x86_64/gluster-3.12/"
+    3-11:
+        description: "Gluster 3.11 from CentOS Storage SIG"
+        baseurl: "http://buildlogs.centos.org/centos/7/storage/x86_64/gluster-3.11/"
+    3-10:
+        description: "Gluster 3.10 from CentOS Storage SIG"
+        baseurl: "http://buildlogs.centos.org/centos/7/storage/x86_64/gluster-3.10/"
+    3-9:
+        description: "Gluster 3.9 from CentOS Storage SIG"
+        baseurl: "http://buildlogs.centos.org/centos/7/storage/x86_64/gluster-3.9/"

--- a/roles/gluster-centos/README.rst
+++ b/roles/gluster-centos/README.rst
@@ -2,5 +2,4 @@
  Gluster-centos
 ================
 
-This role installs gluster packages used by Tendrl project and enables
-glusterd service.
+This role installs gluster server package and enables glusterd service.

--- a/roles/gluster-centos/tasks/main.yml
+++ b/roles/gluster-centos/tasks/main.yml
@@ -1,25 +1,9 @@
-- name: Install GlusterFS
+- name: Install GlusterFS Server
   yum:
-    name="{{ item }}"
-    state=latest
+    name: "{{ item }}"
+    state: latest
   with_items:
-    - glusterfs
-    - glusterfs-fuse
     - glusterfs-server
-    - python-gluster
-    - glusterfs-rdma
-#    - glusterfs-debuginfo
-    - glusterfs-api
-    - glusterfs-client
-    - glusterfs-api-devel
-    - glusterfs-devel
-    - glusterfs-libs
-    - userspace-rcu
-    - glusterfs-cli
-    - glusterfs-events
-    - glusterfs-rdma
-    - glusterfs-client-xlators
-    - glusterfs-extra-xlators
     - glusterfs-geo-replication
   register: task_result
   until: task_result|success

--- a/roles/gluster-centos/tasks/main.yml
+++ b/roles/gluster-centos/tasks/main.yml
@@ -1,7 +1,6 @@
 - name: Install GlusterFS
   yum:
     name="{{ item }}"
-    disable_gpg_check=yes
     state=latest
   with_items:
     - glusterfs


### PR DESCRIPTION
This pull request fixes a rotten gluster setup roles by:

* specifying particular glusterfs releases we can use with the role
* fix wrong way to handle the fact that Storage SIG packages are unsigned
* enable nightly glusterfs builds by default (as suggested by tendrl devs)
* linking to maintainers of the gluster repositories
* removing unnecessary packages during glusterfs installation