### PR TITLE
add client role to general setup playbooks

### DIFF
--- a/qe_pre_installation_tasks.yml
+++ b/qe_pre_installation_tasks.yml
@@ -5,7 +5,7 @@
 # * WORKAROUND: set selinux to permissive mode
 # * enable ntp sync via chronyd
 #
-- hosts: usm_server:usm_nodes
+- hosts: usm_server:usm_nodes:usm_client
   remote_user: root
   tasks:
     - name: upgrade all packages

--- a/qe_reboot.yml
+++ b/qe_reboot.yml
@@ -3,7 +3,7 @@
 # Reboot all machines (usm_server,usm_nodes) and wait till they boot up
 #
 - name: Reboot all servers
-  hosts: "usm_server:usm_nodes"
+  hosts: "usm_server:usm_nodes:usm_client"
   remote_user: root
   tasks:
     - name: install package at
@@ -18,7 +18,7 @@
       shell: "echo reboot | at now"
 
 - name: Wait for all servers to boot up
-  hosts: "usm_server:usm_nodes"
+  hosts: "usm_server:usm_nodes:usm_client"
   gather_facts: no
   remote_user: root
   tasks:

--- a/qe_tools.yml
+++ b/qe_tools.yml
@@ -2,7 +2,7 @@
 #
 # Install useful and auxiliary tools
 #
-- hosts: usm_server:usm_nodes
+- hosts: usm_server:usm_nodes:usm_client
   remote_user: root
   tasks:
     - name: Install useful tools


### PR DESCRIPTION
We are missing few common setup steps on a client machine, this commit fixes the problem.