### PR TITLE
rpm validation setup: update for 1.5.2

### DIFF
--- a/tendrl_unit_test_setup.yml
+++ b/tendrl_unit_test_setup.yml
@@ -11,6 +11,7 @@
   roles:
     - { role: epel, epel_enabled: 1 }
     - qe-tendrl-repo
+    - gluster-centos-repo
   post_tasks:
     - name: upgrade all packages
       yum:

--- a/tendrl_unit_test_setup.yml
+++ b/tendrl_unit_test_setup.yml
@@ -29,3 +29,4 @@
       yum:
         name: 'tendrl*'
         state: latest
+        exclude: 'tendrl-node-selinux'


### PR DESCRIPTION
* tendrl_unit_test_setup: enable gluster repo because of gluster dependencies for tendrl-gluster-integration
* do not install tendrl-node-selinux because of conflict with tendrl-server-selinux
