### PR TITLE
Use tendrl-ansible roles from package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@
 *.retry
 # ini files
 *.ini
+# tendrl-ansible files
+tendrl-ansible-tmp

--- a/qe_get_tendrl_ansible.yml
+++ b/qe_get_tendrl_ansible.yml
@@ -1,0 +1,49 @@
+---
+
+#
+# Get content of tendrl-ansible package
+#
+
+- hosts: usm_server
+  remote_user: root
+  vars:
+    tendrl_ansible_dir: "./tendrl-ansible-tmp/"
+  roles:
+    - qe-tendrl-repo
+  tasks:
+    # This task is not necessary, but we will at least check that
+    # installation works as expected
+    - name: Install tendrl-ansible package
+      yum: name=tendrl-ansible state=latest
+
+    # prepare local directory for tendrl-ansible
+    - name: Remove old '{{ tendrl_ansible_dir }}' directory for tendrl-ansible
+      local_action:
+        module: file
+        state: absent
+        path: "{{ tendrl_ansible_dir }}"
+      run_once: True
+    - name: Create directory for tendrl-ansible
+      local_action:
+        module: file
+        state: directory
+        path: "{{ tendrl_ansible_dir }}"
+      run_once: True
+    # Download tendrl-ansible package on the remote host
+    - name: Download tendrl-ansible package
+      shell: yumdownloader --destdir /tmp/downloaded-tendrl-ansible-rpm/ tendrl-ansible
+    - name: Get name of the downloaded package
+      shell: ls /tmp/downloaded-tendrl-ansible-rpm/
+      register: tendrl_ansible_rpm_name
+    # Fetch tendrl-ansible package from remote host to local host
+    - name: Fetch tendrl-ansible packge to local machine
+      fetch:
+        src: "/tmp/downloaded-tendrl-ansible-rpm/{{ tendrl_ansible_rpm_name.stdout }}"
+        dest: "{{ tendrl_ansible_dir }}{{ tendrl_ansible_rpm_name.stdout }}"
+        flat: yes
+    # Unpack the package on local host
+    - name: Unpack the downloaded package
+      local_action:
+        module: shell rpm2cpio {{ tendrl_ansible_rpm_name.stdout }} | cpio -idmv --no-absolute-filenames
+        chdir: "{{ tendrl_ansible_dir }}"
+      run_once: True

--- a/tendrl.yml
+++ b/tendrl.yml
@@ -11,10 +11,10 @@
     graphite_ip_address: "{{ etcd_ip_address }}"
   roles:
     - { role: epel, epel_enabled: 1 }
-    - grafana-repo
+    - tendrl-ansible.grafana-repo
     - qe-tendrl-repo
-    #- ceph-installer # TODO: make it optional (when we don't deploy ceph)
-    - tendrl-server
+    #- tendrl-ansible.ceph-installer # TODO: make it optional (when we don't deploy ceph)
+    - tendrl-ansible.tendrl-server
   post_tasks:
     - debug: var=hostvars[groups['usm_server'][0]]['admin_password']
     - name: Copy usm.ini template
@@ -33,7 +33,7 @@
   roles:
     - { role: epel, epel_enabled: 1 }
     - qe-tendrl-repo
-    - tendrl-storage-node
+    - tendrl-ansible.tendrl-storage-node
 
 - hosts: gluster
   remote_user: root
@@ -44,5 +44,5 @@
   roles:
     - { role: epel, epel_enabled: 1 }
     - qe-tendrl-repo
-    - gluster-gdeploy-copr
-    - tendrl-storage-node
+    - tendrl-ansible.gluster-gdeploy-copr
+    - tendrl-ansible.tendrl-storage-node


### PR DESCRIPTION
add `qe_get_tendrl_ansible.yml` playbook:
- get tendrl-ansible package and unpack it to local directory
  (by default `./tendrl-ansible-tmp/`)
- add the default *tendrl_ansible_dir* (`./tendrl-ansible-tmp/`) to
  `.gitignore`

rename used tendrl-ansible roles:
- roles from tendrl-ansible package are prefixed by `tendrl-ansible.`
