### PR TITLE
unit test setup: exclude tendrl-server-selinux

### DIFF
--- a/tendrl_unit_test_setup.yml
+++ b/tendrl_unit_test_setup.yml
@@ -29,4 +29,4 @@
       yum:
         name: 'tendrl*'
         state: latest
-        exclude: 'tendrl-node-selinux'
+        exclude: 'tendrl-node-selinux tendrl-server-selinux'


### PR DESCRIPTION
both tendrl-server-selinux and tendrl-node-selinux packages are replaced by tendrl-selinux package