### PR TITLE
add upstream repos only on CentOS

### DIFF
--- a/qe_get_tendrl_ansible.yml
+++ b/qe_get_tendrl_ansible.yml
@@ -9,7 +9,8 @@
   vars:
     tendrl_ansible_dir: "./tendrl-ansible-tmp/"
   roles:
-    - qe-tendrl-repo
+    - role: qe-tendrl-repo
+      when: ansible_distribution == 'CentOS'
   tasks:
     # This task is not necessary, but we will at least check that
     # installation works as expected

--- a/qe_reboot.yml
+++ b/qe_reboot.yml
@@ -1,6 +1,6 @@
 ---
 #
-# Reboot all machines (usm_server,usm_nodes) and wait till they boot up
+# Reboot all machines (usm_server,usm_nodes,usm_client) and wait till they boot up
 #
 - name: Reboot all servers
   hosts: "usm_server:usm_nodes:usm_client"

--- a/tendrl.yml
+++ b/tendrl.yml
@@ -16,9 +16,11 @@
     - role: qe-ssl-cert
       ssl_cert_name: "etcd"
       ssl_key_perm: "0644"
-    - { role: epel, epel_enabled: 1 }
-    - tendrl-ansible.grafana-repo
-    - qe-tendrl-repo
+    - { role: epel, epel_enabled: 1, when: ansible_distribution == 'CentOS' }
+    - role: tendrl-ansible.grafana-repo
+      when: ansible_distribution == 'CentOS'
+    - role: qe-tendrl-repo
+      when: ansible_distribution == 'CentOS'
     #- tendrl-ansible.ceph-installer # TODO: make it optional (when we don't deploy ceph)
     - tendrl-ansible.tendrl-server
   post_tasks:
@@ -42,8 +44,9 @@
   roles:
     - role: qe-ssl-cert
       ssl_cert_name: "etcd"
-    - { role: epel, epel_enabled: 1 }
-    - qe-tendrl-repo
+    - { role: epel, epel_enabled: 1, when: ansible_distribution == 'CentOS' }
+    - role: qe-tendrl-repo
+      when: ansible_distribution == 'CentOS'
     - tendrl-ansible.tendrl-storage-node
 
 - hosts: gluster
@@ -58,7 +61,9 @@
   roles:
     - role: qe-ssl-cert
       ssl_cert_name: "etcd"
-    - { role: epel, epel_enabled: 1 }
-    - qe-tendrl-repo
-    - tendrl-ansible.gluster-gdeploy-copr
+    - { role: epel, epel_enabled: 1, when: ansible_distribution == 'CentOS' }
+    - role: qe-tendrl-repo
+      when: ansible_distribution == 'CentOS'
+    - role: tendrl-ansible.gluster-gdeploy-copr
+      when: ansible_distribution == 'CentOS'
     - tendrl-ansible.tendrl-storage-node


### PR DESCRIPTION
Playbooks tendrl.yml,  qe-tendrl-repo.yml: add condition for adding upstream repos (add upstream repos only on CentOS)
This change will allow usage of of the playbooks on both CentOS and RHEL.
