### PR TITLE
make possible epel installation on rhel

### DIFF
--- a/roles/epel/tasks/main.yml
+++ b/roles/epel/tasks/main.yml
@@ -9,6 +9,7 @@
     - epel_enabled
     - ansible_distribution == 'RedHat'
     - qe_not_production_testing_server is not defined
+    - not qe_not_production_testing_server|bool
 
 - name: Copy EPEL rpm-gpg key first (hack)
   copy:

--- a/roles/epel/tasks/main.yml
+++ b/roles/epel/tasks/main.yml
@@ -5,7 +5,10 @@
 
 - name: Check if EPEL is not permanently enabled on RHEL
   fail: msg="Do not permanently enable EPEL on RHEL!"
-  when: epel_enabled and ansible_distribution == 'RedHat'
+  when:
+    - epel_enabled
+    - ansible_distribution == 'RedHat'
+    - qe_not_production_testing_server is not defined
 
 - name: Copy EPEL rpm-gpg key first (hack)
   copy:

--- a/roles/qe-server/meta/main.yml
+++ b/roles/qe-server/meta/main.yml
@@ -1,4 +1,4 @@
 ---
 dependencies:
-  - { role: epel, epel_enabled: 1 }
+  - { role: epel, epel_enabled: 1, qe_not_production_testing_server: True}
   - { role: rh-python35 }


### PR DESCRIPTION
* allow epel on rhel, when `qe_not_production_testing_server` parameter is defined