### PR TITLE
tendrl firewall: fix monitoring-integration port

### DIFF
--- a/firewall.tendrl.yml
+++ b/firewall.tendrl.yml
@@ -64,7 +64,7 @@
  
   - name: Enable port for tendrl-monitoring-integration
     firewalld:
-      port=8989/tcp
+      port=8789/tcp
       zone=public permanent=true state=enabled immediate=true
 
 - name: Configure and enable firewalld on Tendrl storage nodes


### PR DESCRIPTION
* Port opened for tendrl-monitoring-integration should be 8789, not 8989.
* fix https://github.com/usmqe/usmqe-setup/issues/166