### PR TITLE
exclude grafana-4.6.* in tendrl_unit_test_setup.yml

### DIFF
--- a/tendrl_unit_test_setup.yml
+++ b/tendrl_unit_test_setup.yml
@@ -20,6 +20,10 @@
       yum:
         name: 'python-mock'
         state: latest
+    - name: "WORKAROUND - exclude=grafana-4.6.*"
+      lineinfile:
+        path: '/etc/yum.conf'
+        line: 'exclude=grafana-4.6.*'
     - name: Install tendrl packages
       yum:
         name: 'tendrl*'


### PR DESCRIPTION
because tendrl-monitoring-integration depends on "grafana < 4.5.3"

Fixing issue with preparation of test server for package validation (for example: https://ci.centos.org/view/tendrl-build-release/job/tendrl-pkgval-X-release-prepare/)