### PR TITLE
Fix munin node installation

### DIFF
--- a/qe_munin_node.yml
+++ b/qe_munin_node.yml
@@ -4,4 +4,5 @@
 - hosts: "usm_server:usm_nodes:usm_client"
   remote_user: root
   roles:
+    - { role: epel, epel_enabled: 1, when: ansible_distribution == 'CentOS' }
     - qe-munin-node

--- a/roles/qe-munin-node/tasks/main.yml
+++ b/roles/qe-munin-node/tasks/main.yml
@@ -3,6 +3,10 @@
   package:
     name: munin-node
     state: present
+  retries: 5
+  delay: 5
+  register: result
+  until: 'result|success'
   notify:
     - restart munin-node service
 


### PR DESCRIPTION
Explicitly enable epel during munin-node installation.
This will fix issue with munin-node installation without installed Tendrl.