### PR TITLE
Unify group names with tendrl-ansible

### DIFF
--- a/configure_admin_email_notifications.yml
+++ b/configure_admin_email_notifications.yml
@@ -12,7 +12,7 @@
 #   tendrl_password: password for tendrl user (default: adminuser)
 #
 
-- hosts: usm_server
+- hosts: tendrl-server
   remote_user: root
   vars:
     tendrl_user: "admin"

--- a/firewall.skyrings.yml
+++ b/firewall.skyrings.yml
@@ -3,7 +3,7 @@
 # This playbook just tries to enable firewall on all machines of the cluster.
 
 - name: Configure and enable firewalld on skyrings/RHSCon 2.0 server machine
-  hosts: usm_server
+  hosts: tendrl-server
   user: root
   roles:
     - firewall-skyrings

--- a/firewall.tendrl.yml
+++ b/firewall.tendrl.yml
@@ -4,7 +4,7 @@
 #
 # Note: considering etcd, graphite, grafana and tendrl servers run on server machine.
 
-- hosts: usm_server:usm_nodes
+- hosts: tendrl-server:usm_nodes
   remote_user: root
   pre_tasks:
     - name: install firewalld
@@ -17,7 +17,7 @@
       delay: 5
 
 - name: Configure and enable firewalld on Tendrl server machine
-  hosts: usm_server
+  hosts: tendrl-server
   user: root
   vars:
     tendrl_uses_https: false

--- a/firewall.tendrl.yml
+++ b/firewall.tendrl.yml
@@ -4,7 +4,7 @@
 #
 # Note: considering etcd, graphite, grafana and tendrl servers run on server machine.
 
-- hosts: tendrl-server:usm_nodes
+- hosts: tendrl-server:gluster-servers
   remote_user: root
   pre_tasks:
     - name: install firewalld
@@ -68,7 +68,7 @@
       zone=public permanent=true state=enabled immediate=true
 
 - name: Configure and enable firewalld on Tendrl storage nodes
-  hosts: usm_nodes
+  hosts: gluster-servers
   user: root
   tasks:
   - name: Make sure firewalld is enabled and running

--- a/qe_evidence.skyrings.yml
+++ b/qe_evidence.skyrings.yml
@@ -41,7 +41,7 @@
     - role: qe-evidence
 
 - name: Download logs from Ceph Storage machines
-  hosts: usm_nodes
+  hosts: gluster-servers
   user: root
   vars:
     evidence_dirs:

--- a/qe_evidence.skyrings.yml
+++ b/qe_evidence.skyrings.yml
@@ -22,7 +22,7 @@
     - qe-evidence-probe
 
 - name: Download evidence from RHSC 2.0 machine
-  hosts: usm_server
+  hosts: tendrl-server
   user: root
   vars:
     evidence_dirs:

--- a/qe_evidence.tendrl.yml
+++ b/qe_evidence.tendrl.yml
@@ -60,7 +60,7 @@
     - qe-evidence-probe-journald
 
 - name: Download logs from Storage machines
-  hosts: usm_nodes
+  hosts: gluster-servers
   user: root
   vars:
     evidence_dirs:

--- a/qe_evidence.tendrl.yml
+++ b/qe_evidence.tendrl.yml
@@ -30,7 +30,7 @@
     - qe-evidence-probe
 
 - name: Download evidence from Tendrl server machine
-  hosts: usm_server
+  hosts: tendrl-server
   user: root
   vars:
     evidence_dirs:

--- a/qe_get_tendrl_ansible.yml
+++ b/qe_get_tendrl_ansible.yml
@@ -4,7 +4,7 @@
 # Get content of tendrl-ansible package
 #
 
-- hosts: usm_server
+- hosts: tendrl-server
   remote_user: root
   vars:
     tendrl_ansible_dir: "./tendrl-ansible-tmp/"

--- a/qe_munin_node.yml
+++ b/qe_munin_node.yml
@@ -1,7 +1,7 @@
 ---
 # install and configure munin-node
 
-- hosts: "tendrl-server:usm_nodes:usm_client"
+- hosts: "tendrl-server:gluster-servers:usm_client"
   remote_user: root
   roles:
     - { role: epel, epel_enabled: 1, when: ansible_distribution == 'CentOS' }

--- a/qe_munin_node.yml
+++ b/qe_munin_node.yml
@@ -1,7 +1,7 @@
 ---
 # install and configure munin-node
 
-- hosts: "usm_server:usm_nodes:usm_client"
+- hosts: "tendrl-server:usm_nodes:usm_client"
   remote_user: root
   roles:
     - { role: epel, epel_enabled: 1, when: ansible_distribution == 'CentOS' }

--- a/qe_pre_installation_tasks.yml
+++ b/qe_pre_installation_tasks.yml
@@ -5,7 +5,7 @@
 #   (containing comma separated list of urls pointing to repo config files)
 #   - additional_repos
 #   - additional_repos_tendrl-server
-#   - additional_repos_usm_nodes
+#   - additional_repos_gluster-servers
 #   - additional_repos_usm_client
 # * update all packages
 # * enable ntp sync via chronyd
@@ -24,7 +24,7 @@
       with_items: "{{ (additional_repos_tendrl-server | default('')).split(',') }}"
       when: item != ""
 
-- hosts: usm_nodes
+- hosts: gluster-servers
   remote_user: root
   tasks:
     - name: Add any additional repo(s)
@@ -35,7 +35,7 @@
       delay: 5
       register: result
       until: 'result|success'
-      with_items: "{{ (additional_repos_usm_nodes | default('')).split(',') }}"
+      with_items: "{{ (additional_repos_gluster-servers | default('')).split(',') }}"
       when: item != ""
 
 - hosts: usm_client
@@ -52,7 +52,7 @@
       with_items: "{{ (additional_repos_usm_client | default('')).split(',') }}"
       when: item != ""
 
-- hosts: tendrl-server:usm_nodes:usm_client
+- hosts: tendrl-server:gluster-servers:usm_client
   remote_user: root
   tasks:
     - name: Add any additional repo(s)

--- a/qe_pre_installation_tasks.yml
+++ b/qe_pre_installation_tasks.yml
@@ -4,8 +4,8 @@
 # * add any additional repo(s) if required, controlled by following variables
 #   (containing comma separated list of urls pointing to repo config files)
 #   - additional_repos
-#   - additional_repos_tendrl-server
-#   - additional_repos_gluster-servers
+#   - additional_repos_tendrl_server
+#   - additional_repos_gluster_servers
 #   - additional_repos_usm_client
 # * update all packages
 # * enable ntp sync via chronyd
@@ -21,7 +21,7 @@
       delay: 5
       register: result
       until: 'result|success'
-      with_items: "{{ (additional_repos_tendrl-server | default('')).split(',') }}"
+      with_items: "{{ (additional_repos_tendrl_server | default('')).split(',') }}"
       when: item != ""
 
 - hosts: gluster-servers
@@ -35,7 +35,7 @@
       delay: 5
       register: result
       until: 'result|success'
-      with_items: "{{ (additional_repos_gluster-servers | default('')).split(',') }}"
+      with_items: "{{ (additional_repos_gluster_servers | default('')).split(',') }}"
       when: item != ""
 
 - hosts: usm_client

--- a/qe_pre_installation_tasks.yml
+++ b/qe_pre_installation_tasks.yml
@@ -4,13 +4,13 @@
 # * add any additional repo(s) if required, controlled by following variables
 #   (containing comma separated list of urls pointing to repo config files)
 #   - additional_repos
-#   - additional_repos_usm_server
+#   - additional_repos_tendrl-server
 #   - additional_repos_usm_nodes
 #   - additional_repos_usm_client
 # * update all packages
 # * enable ntp sync via chronyd
 #
-- hosts: usm_server
+- hosts: tendrl-server
   remote_user: root
   tasks:
     - name: Add any additional repo(s)
@@ -21,7 +21,7 @@
       delay: 5
       register: result
       until: 'result|success'
-      with_items: "{{ (additional_repos_usm_server | default('')).split(',') }}"
+      with_items: "{{ (additional_repos_tendrl-server | default('')).split(',') }}"
       when: item != ""
 
 - hosts: usm_nodes
@@ -52,7 +52,7 @@
       with_items: "{{ (additional_repos_usm_client | default('')).split(',') }}"
       when: item != ""
 
-- hosts: usm_server:usm_nodes:usm_client
+- hosts: tendrl-server:usm_nodes:usm_client
   remote_user: root
   tasks:
     - name: Add any additional repo(s)

--- a/qe_reboot.yml
+++ b/qe_reboot.yml
@@ -1,9 +1,9 @@
 ---
 #
-# Reboot all machines (usm_server,usm_nodes,usm_client) and wait till they boot up
+# Reboot all machines (tendrl-server,usm_nodes,usm_client) and wait till they boot up
 #
 - name: Reboot all servers
-  hosts: "usm_server:usm_nodes:usm_client"
+  hosts: "tendrl-server:usm_nodes:usm_client"
   remote_user: root
   tasks:
     - name: install package at
@@ -18,7 +18,7 @@
       shell: "echo reboot | at now"
 
 - name: Wait for all servers to boot up
-  hosts: "usm_server:usm_nodes:usm_client"
+  hosts: "tendrl-server:usm_nodes:usm_client"
   gather_facts: no
   remote_user: root
   tasks:

--- a/qe_reboot.yml
+++ b/qe_reboot.yml
@@ -1,9 +1,9 @@
 ---
 #
-# Reboot all machines (tendrl-server,usm_nodes,usm_client) and wait till they boot up
+# Reboot all machines (tendrl-server,gluster-servers,usm_client) and wait till they boot up
 #
 - name: Reboot all servers
-  hosts: "tendrl-server:usm_nodes:usm_client"
+  hosts: "tendrl-server:gluster-servers:usm_client"
   remote_user: root
   tasks:
     - name: install package at
@@ -18,7 +18,7 @@
       shell: "echo reboot | at now"
 
 - name: Wait for all servers to boot up
-  hosts: "tendrl-server:usm_nodes:usm_client"
+  hosts: "tendrl-server:gluster-servers:usm_client"
   gather_facts: no
   remote_user: root
   tasks:

--- a/qe_server_sshkey.yml
+++ b/qe_server_sshkey.yml
@@ -24,7 +24,7 @@
     register: usmqe_ssh_key
 
 - name: Deploy ssh public key of usmqe user to test machines
-  hosts: tendrl-server:usm_nodes:usm_client
+  hosts: tendrl-server:gluster-servers:usm_client
   user: root
   vars:
     ssh_key: "{{ hostvars[groups['qe_server'][0]].usmqe_ssh_key.stdout }}"

--- a/qe_server_sshkey.yml
+++ b/qe_server_sshkey.yml
@@ -24,7 +24,7 @@
     register: usmqe_ssh_key
 
 - name: Deploy ssh public key of usmqe user to test machines
-  hosts: usm_server:usm_nodes:usm_client
+  hosts: tendrl-server:usm_nodes:usm_client
   user: root
   vars:
     ssh_key: "{{ hostvars[groups['qe_server'][0]].usmqe_ssh_key.stdout }}"

--- a/qe_ssl_certs.etcd.yml
+++ b/qe_ssl_certs.etcd.yml
@@ -9,7 +9,7 @@
       ssl_key_perm: "0644"
       # ssl_owner: "etcd"
 
-- hosts: usm_nodes
+- hosts: gluster-servers
   remote_user: root
   roles:
     - role: qe-ssl-cert

--- a/qe_ssl_certs.etcd.yml
+++ b/qe_ssl_certs.etcd.yml
@@ -1,7 +1,7 @@
 ---
 # SSL setup for etcd client-server authentication
 
-- hosts: usm_server
+- hosts: tendrl-server
   remote_user: root
   roles:
     - role: qe-ssl-cert

--- a/qe_ssl_certs.yml
+++ b/qe_ssl_certs.yml
@@ -3,7 +3,7 @@
 # obtain ssl certs on all servers
 #
 
-- hosts: usm_server:usm_nodes:usm_client
+- hosts: tendrl-server:usm_nodes:usm_client
   remote_user: root
   roles:
     - {role: qe-ssl-cert, ssl_cert_name: "server"}

--- a/qe_ssl_certs.yml
+++ b/qe_ssl_certs.yml
@@ -3,7 +3,7 @@
 # obtain ssl certs on all servers
 #
 
-- hosts: tendrl-server:usm_nodes:usm_client
+- hosts: tendrl-server:gluster-servers:usm_client
   remote_user: root
   roles:
     - {role: qe-ssl-cert, ssl_cert_name: "server"}

--- a/qe_tendrl_admin.yml
+++ b/qe_tendrl_admin.yml
@@ -1,6 +1,6 @@
 ---
 - name: Change password of tendrl admin (usm_username from conf_path ini file)
-  hosts: usm_server
+  hosts: tendrl-server
   vars:
     new_password: "admin123"
 

--- a/qe_tools.yml
+++ b/qe_tools.yml
@@ -2,7 +2,7 @@
 #
 # Install useful and auxiliary tools
 #
-- hosts: tendrl-server:usm_nodes:usm_client
+- hosts: tendrl-server:gluster-servers:usm_client
   remote_user: root
   tasks:
     - name: Install useful tools

--- a/qe_tools.yml
+++ b/qe_tools.yml
@@ -2,7 +2,7 @@
 #
 # Install useful and auxiliary tools
 #
-- hosts: usm_server:usm_nodes:usm_client
+- hosts: tendrl-server:usm_nodes:usm_client
   remote_user: root
   tasks:
     - name: Install useful tools

--- a/services.skyrings.yml
+++ b/services.skyrings.yml
@@ -6,7 +6,7 @@
 # ansible-playbook -i usm2.hosts --extra-vars service_state=started services.skyrings.yml
 
 - name: Start/Stop all services on Skyrings server
-  hosts: "usm_server"
+  hosts: "tendrl-server"
   remote_user: root
 
   tasks:

--- a/templates/usm.ini.j2
+++ b/templates/usm.ini.j2
@@ -1,11 +1,11 @@
 [usmqepytest]
 usm_log_level = DEBUG
 usm_username = admin
-usm_password = {{ hostvars[groups['usm_server'][0]]['admin_password'].stdout }}
-usm_web_url = http://{{ groups['usm_server'][0] }}
-usm_api_url = http://{{ groups['usm_server'][0] }}/api/1.0/
-etcd_api_url = http://{{ groups['usm_server'][0] }}:2379/v2/
-graphite_api_url = http://{{ groups['usm_server'][0] }}:10080/
+usm_password = {{ hostvars[groups['tendrl-server'][0]]['admin_password'].stdout }}
+usm_web_url = http://{{ groups['tendrl-server'][0] }}
+usm_api_url = http://{{ groups['tendrl-server'][0] }}/api/1.0/
+etcd_api_url = http://{{ groups['tendrl-server'][0] }}:2379/v2/
+graphite_api_url = http://{{ groups['tendrl-server'][0] }}:10080/
 usm_ca_cert = conf/ooo_ca.crt
 usm_brick_path = /bricks/fs_gluster01/brick
 usm_gluster_role = gluster

--- a/tendrl.yml
+++ b/tendrl.yml
@@ -4,7 +4,7 @@
 # Install Tendrl server
 #
 
-- hosts: usm_server
+- hosts: tendrl-server
   remote_user: root
   vars:
     etcd_fqdn: "{{ ansible_fqdn }}"
@@ -25,10 +25,10 @@
     #- tendrl-ansible.ceph-installer # TODO: make it optional (when we don't deploy ceph)
     - tendrl-ansible.tendrl-server
   post_tasks:
-    - debug: var=hostvars[groups['usm_server'][0]]['admin_password']
+    - debug: var=hostvars[groups['tendrl-server'][0]]['admin_password']
     - name: Copy usm.ini template
       local_action: template src=./templates/usm.ini.j2 dest=./usm.ini
-      when: hostvars[groups['usm_server'][0]]['admin_password'].changed
+      when: hostvars[groups['tendrl-server'][0]]['admin_password'].changed
 
 #
 # Install Tendrl on storage nodes
@@ -37,8 +37,8 @@
 - hosts: ceph_osd:ceph_mon
   remote_user: root
   vars:
-    etcd_fqdn: "{{ hostvars[groups['usm_server'][0]].ansible_fqdn }}"
-    graphite_fqdn: "{{ hostvars[groups['usm_server'][0]].ansible_fqdn }}"
+    etcd_fqdn: "{{ hostvars[groups['tendrl-server'][0]].ansible_fqdn }}"
+    graphite_fqdn: "{{ hostvars[groups['tendrl-server'][0]].ansible_fqdn }}"
     etcd_tls_client_auth: True
     etcd_trusted_ca_file: "/etc/pki/tls/certs/ca-usmqe.crt"
   roles:
@@ -53,8 +53,8 @@
 - hosts: gluster
   remote_user: root
   vars:
-    etcd_fqdn: "{{ hostvars[groups['usm_server'][0]].ansible_fqdn }}"
-    graphite_fqdn: "{{ hostvars[groups['usm_server'][0]].ansible_fqdn }}"
+    etcd_fqdn: "{{ hostvars[groups['tendrl-server'][0]].ansible_fqdn }}"
+    graphite_fqdn: "{{ hostvars[groups['tendrl-server'][0]].ansible_fqdn }}"
     etcd_tls_client_auth: True
     etcd_trusted_ca_file: "/etc/pki/tls/certs/ca-usmqe.crt"
   roles:

--- a/test_setup.smtp.yml
+++ b/test_setup.smtp.yml
@@ -61,7 +61,7 @@
         state: started
         enabled: yes
 
-- hosts: usm_server
+- hosts: tendrl-server
   remote_user: root
   handlers:
     - name: restart tendrl-notifier
@@ -78,7 +78,7 @@
     # notifier sends email alerts (for tendrl admin) to this email address
     tendrl_admin_recipient_email: "root@{{ groups['usm_client'][0] }}"
     # notifier sends email alerts from this email address
-    tendrl_notifier_email_id: "tendrl@{{ groups['usm_server'][0] }}"
+    tendrl_notifier_email_id: "tendrl@{{ groups['tendrl-server'][0] }}"
     # smpt server which notifier uses to send email
     tendrl_notifier_email_smtp_server: "{{ groups['usm_client'][0] }}"
     # smpt port of server specified above

--- a/test_setup.snmp.yml
+++ b/test_setup.snmp.yml
@@ -7,7 +7,7 @@
 #
 # * snmptrapd (daemon receiving snmp trap messages) runs on usm_client
 # * tendrl is configured to send snmp traps to usm_client machine, which is
-#   implemented by tendrl-notifier service running on usm_server machine
+#   implemented by tendrl-notifier service running on tendrl-server machine
 #
 # The configuration is based on:
 #
@@ -89,7 +89,7 @@
         state: started
         enabled: yes
 
-- hosts: usm_server
+- hosts: tendrl-server
   remote_user: root
   vars:
     qe_snmp_user: "tendrlTrapUser"

--- a/test_teardown.smtp.yml
+++ b/test_teardown.smtp.yml
@@ -1,6 +1,6 @@
 ---
 
-- hosts: usm_server
+- hosts: tendrl-server
   remote_user: root
   handlers:
     - name: restart tendrl-notifier

--- a/test_teardown.snmp.yml
+++ b/test_teardown.snmp.yml
@@ -21,7 +21,7 @@
         - '^authUser.*{{ qe_snmp_user }}'
         - '^createUser.*{{ qe_snmp_user }}'
 
-- hosts: usm_server
+- hosts: tendrl-server
   remote_user: root
   vars:
     qe_snmp_user: "tendrlTrapUser"


### PR DESCRIPTION
Do we wan't to unify the ansible group names with `tendrl-ansible`?

* use `tendrl-server` instead of `usm_server` ansible group
* use `gluster-servers` instead of `usm_nodes` ansible group

If we decide to merge this PR, it has to be coordinated with changes in other parts of the workflow.