### PR TITLE
Revert "WORKAROUND: exclude grafana-4.6.*"

### DIFF
--- a/tendrl_unit_test_setup.yml
+++ b/tendrl_unit_test_setup.yml
@@ -20,10 +20,6 @@
       yum:
         name: 'python-mock'
         state: latest
-    - name: "WORKAROUND - exclude=grafana-4.6.*"
-      lineinfile:
-        path: '/etc/yum.conf'
-        line: 'exclude=grafana-4.6.*'
     - name: Install tendrl packages
       yum:
         name: 'tendrl*'


### PR DESCRIPTION
This reverts commit 64d18e21f93f0d2c247052b54b3055419c168317.
Fixes https://github.com/usmqe/usmqe-setup/issues/171