### PR TITLE
ansible2gdeploy - host specification type (fqdn, short name, ip, mixed, random)

### DIFF
--- a/bin/ansible2gdeploy.py
+++ b/bin/ansible2gdeploy.py
@@ -61,6 +61,8 @@ def host_mixed(fqdn):
     Return host's fqdn, hostname or IP - sequentially selected.
     """
     choices = (host_fqdn, host_short, host_ip)
+    # HACK: instead of using a global variable or iterator,
+    # we just push an attribute to the function object to preserve global state
     try:
         current_i = host_mixed.i
     except AttributeError:

--- a/bin/ansible2gdeploy.py
+++ b/bin/ansible2gdeploy.py
@@ -93,6 +93,7 @@ def main():
         "-i",
         dest="inventory",
         action="store",
+        required=True,
         help="ansible inventory (aka hosts) file")
     ap.add_argument(
         "-p",

--- a/bin/ansible2gdeploy.py
+++ b/bin/ansible2gdeploy.py
@@ -1,20 +1,22 @@
 #!/usr/bin/env python3
 # -*- coding: utf8 -*-
 
-# This script allows you to replace hosts and client hosts in gdeploy
-# config file, addressing use case described here:
-# https://github.com/gluster/gdeploy/issues/422
+"""
+This script allows you to replace hosts and client hosts in gdeploy
+config file, addressing use case described here:
+https://github.com/gluster/gdeploy/issues/422
 
-# To use this script on umsqe server with python3 software collection,
-# run it via:
-#
-# python ./bin/ansible2gdeploy.py -i usm1.hosts \
-#   gdeploy_config/volume_alpha_distrep_6x2.create.conf
-#
-# python ./bin/ansible2gdeploy.py -i usm1.hosts \
-#   -p UPDATE_ -s vdb,vdc,vdd,vde,vdf,vdg \
-#   gdeploy_config/volume_alpha_distrep_6x2.create.conf \
-#   gdeploy_config/volume_beta_arbiter_2_plus_1x2.create.conf \
+To use this script on umsqe server with python3 software collection,
+run it via:
+
+python ./bin/ansible2gdeploy.py -i usm1.hosts \
+  gdeploy_config/volume_alpha_distrep_6x2.create.conf
+
+python ./bin/ansible2gdeploy.py -i usm1.hosts \
+  -p UPDATE_ -s vdb,vdc,vdd,vde,vdf,vdg \
+  gdeploy_config/volume_alpha_distrep_6x2.create.conf \
+  gdeploy_config/volume_beta_arbiter_2_plus_1x2.create.conf \
+"""
 
 
 from configparser import ConfigParser

--- a/bin/ansible2gdeploy.py
+++ b/bin/ansible2gdeploy.py
@@ -179,8 +179,10 @@ def main():
         gdeploy_conf.add_section("hosts")
         print("hosts_definition: %s" % args.hosts_definition, file=sys.stderr)
         for server in servers:
-            gdeploy_conf.set("hosts", \
-                    host_transformation[args.hosts_definition](server), None)
+            gdeploy_conf.set(
+                "hosts",
+                host_transformation[args.hosts_definition](server),
+                None)
 
         # configure client
         if gdeploy_conf.has_section("clients"):


### PR DESCRIPTION
* add parameter `-h`/`--host-definition {fqdn,short,ip,mixed,random}` (default: `fqdn`)
  Specifies how to define hosts in gdeploy config.