### PR TITLE
Add bunch of volume configurations for creation multiple higher number of volumes

### DIFF
--- a/gdeploy_config/dahorak/volume_a01_distrep_1brick.create.conf
+++ b/gdeploy_config/dahorak/volume_a01_distrep_1brick.create.conf
@@ -1,0 +1,27 @@
+# USM QE a01 configuration for GlusterFS
+#
+# This gdeploy config file assumes that we have:
+# * even number of Gluster storage servers
+# * 1 block device on each host (storage server) named /dev/vd{b,...}
+
+[hosts]
+
+[peer]
+action=probe
+ignore_peer_errors=no
+
+[backend-setup]
+devices=vdb
+vgs=vg_a01_distrep_1
+pools=pool_a01_distrep_1
+lvs=lv_a01_distrep_1
+mountpoints=/mnt/brick_a01_distrep_1
+brick_dirs=/mnt/brick_a01_distrep_1/brick
+
+[volume]
+volname=volume_a01_distrep
+action=create
+brick_dirs=/mnt/brick_a01_distrep_1/brick
+transport=tcp
+replica=yes
+replica_count=2

--- a/gdeploy_config/dahorak/volume_a01_distrep_1brick.mount.conf
+++ b/gdeploy_config/dahorak/volume_a01_distrep_1brick.mount.conf
@@ -1,0 +1,14 @@
+# USM QE a01 configuration for GlusterFS
+#
+# This gdeploy config file assumes that we have:
+# * 1 client machine (GlusterFS client)
+
+[hosts]
+
+
+[clients]
+volname=volume_a01_distrep
+action=mount
+fstype=glusterfs
+client_mount_points=/mnt/volume_a01_distrep
+hosts=

--- a/gdeploy_config/dahorak/volume_a02_distrep_1brick.create.conf
+++ b/gdeploy_config/dahorak/volume_a02_distrep_1brick.create.conf
@@ -1,0 +1,27 @@
+# USM QE a02 configuration for GlusterFS
+#
+# This gdeploy config file assumes that we have:
+# * even number of Gluster storage servers
+# * 1 block device on each host (storage server) named /dev/vd{b,...}
+
+[hosts]
+
+[peer]
+action=probe
+ignore_peer_errors=no
+
+[backend-setup]
+devices=vdb
+vgs=vg_a02_distrep_1
+pools=pool_a02_distrep_1
+lvs=lv_a02_distrep_1
+mountpoints=/mnt/brick_a02_distrep_1
+brick_dirs=/mnt/brick_a02_distrep_1/brick
+
+[volume]
+volname=volume_a02_distrep
+action=create
+brick_dirs=/mnt/brick_a02_distrep_1/brick
+transport=tcp
+replica=yes
+replica_count=2

--- a/gdeploy_config/dahorak/volume_a02_distrep_1brick.mount.conf
+++ b/gdeploy_config/dahorak/volume_a02_distrep_1brick.mount.conf
@@ -1,0 +1,14 @@
+# USM QE a02 configuration for GlusterFS
+#
+# This gdeploy config file assumes that we have:
+# * 1 client machine (GlusterFS client)
+
+[hosts]
+
+
+[clients]
+volname=volume_a02_distrep
+action=mount
+fstype=glusterfs
+client_mount_points=/mnt/volume_a02_distrep
+hosts=

--- a/gdeploy_config/dahorak/volume_a03_distrep_1brick.create.conf
+++ b/gdeploy_config/dahorak/volume_a03_distrep_1brick.create.conf
@@ -1,0 +1,27 @@
+# USM QE a03 configuration for GlusterFS
+#
+# This gdeploy config file assumes that we have:
+# * even number of Gluster storage servers
+# * 1 block device on each host (storage server) named /dev/vd{b,...}
+
+[hosts]
+
+[peer]
+action=probe
+ignore_peer_errors=no
+
+[backend-setup]
+devices=vdb
+vgs=vg_a03_distrep_1
+pools=pool_a03_distrep_1
+lvs=lv_a03_distrep_1
+mountpoints=/mnt/brick_a03_distrep_1
+brick_dirs=/mnt/brick_a03_distrep_1/brick
+
+[volume]
+volname=volume_a03_distrep
+action=create
+brick_dirs=/mnt/brick_a03_distrep_1/brick
+transport=tcp
+replica=yes
+replica_count=2

--- a/gdeploy_config/dahorak/volume_a03_distrep_1brick.mount.conf
+++ b/gdeploy_config/dahorak/volume_a03_distrep_1brick.mount.conf
@@ -1,0 +1,14 @@
+# USM QE a03 configuration for GlusterFS
+#
+# This gdeploy config file assumes that we have:
+# * 1 client machine (GlusterFS client)
+
+[hosts]
+
+
+[clients]
+volname=volume_a03_distrep
+action=mount
+fstype=glusterfs
+client_mount_points=/mnt/volume_a03_distrep
+hosts=

--- a/gdeploy_config/dahorak/volume_a04_distrep_1brick.create.conf
+++ b/gdeploy_config/dahorak/volume_a04_distrep_1brick.create.conf
@@ -1,0 +1,27 @@
+# USM QE a04 configuration for GlusterFS
+#
+# This gdeploy config file assumes that we have:
+# * even number of Gluster storage servers
+# * 1 block device on each host (storage server) named /dev/vd{b,...}
+
+[hosts]
+
+[peer]
+action=probe
+ignore_peer_errors=no
+
+[backend-setup]
+devices=vdb
+vgs=vg_a04_distrep_1
+pools=pool_a04_distrep_1
+lvs=lv_a04_distrep_1
+mountpoints=/mnt/brick_a04_distrep_1
+brick_dirs=/mnt/brick_a04_distrep_1/brick
+
+[volume]
+volname=volume_a04_distrep
+action=create
+brick_dirs=/mnt/brick_a04_distrep_1/brick
+transport=tcp
+replica=yes
+replica_count=2

--- a/gdeploy_config/dahorak/volume_a04_distrep_1brick.mount.conf
+++ b/gdeploy_config/dahorak/volume_a04_distrep_1brick.mount.conf
@@ -1,0 +1,14 @@
+# USM QE a04 configuration for GlusterFS
+#
+# This gdeploy config file assumes that we have:
+# * 1 client machine (GlusterFS client)
+
+[hosts]
+
+
+[clients]
+volname=volume_a04_distrep
+action=mount
+fstype=glusterfs
+client_mount_points=/mnt/volume_a04_distrep
+hosts=

--- a/gdeploy_config/dahorak/volume_a05_distrep_1brick.create.conf
+++ b/gdeploy_config/dahorak/volume_a05_distrep_1brick.create.conf
@@ -1,0 +1,27 @@
+# USM QE a05 configuration for GlusterFS
+#
+# This gdeploy config file assumes that we have:
+# * even number of Gluster storage servers
+# * 1 block device on each host (storage server) named /dev/vd{b,...}
+
+[hosts]
+
+[peer]
+action=probe
+ignore_peer_errors=no
+
+[backend-setup]
+devices=vdb
+vgs=vg_a05_distrep_1
+pools=pool_a05_distrep_1
+lvs=lv_a05_distrep_1
+mountpoints=/mnt/brick_a05_distrep_1
+brick_dirs=/mnt/brick_a05_distrep_1/brick
+
+[volume]
+volname=volume_a05_distrep
+action=create
+brick_dirs=/mnt/brick_a05_distrep_1/brick
+transport=tcp
+replica=yes
+replica_count=2

--- a/gdeploy_config/dahorak/volume_a05_distrep_1brick.mount.conf
+++ b/gdeploy_config/dahorak/volume_a05_distrep_1brick.mount.conf
@@ -1,0 +1,14 @@
+# USM QE a05 configuration for GlusterFS
+#
+# This gdeploy config file assumes that we have:
+# * 1 client machine (GlusterFS client)
+
+[hosts]
+
+
+[clients]
+volname=volume_a05_distrep
+action=mount
+fstype=glusterfs
+client_mount_points=/mnt/volume_a05_distrep
+hosts=

--- a/gdeploy_config/dahorak/volume_a06_distrep_1brick.create.conf
+++ b/gdeploy_config/dahorak/volume_a06_distrep_1brick.create.conf
@@ -1,0 +1,27 @@
+# USM QE a06 configuration for GlusterFS
+#
+# This gdeploy config file assumes that we have:
+# * even number of Gluster storage servers
+# * 1 block device on each host (storage server) named /dev/vd{b,...}
+
+[hosts]
+
+[peer]
+action=probe
+ignore_peer_errors=no
+
+[backend-setup]
+devices=vdb
+vgs=vg_a06_distrep_1
+pools=pool_a06_distrep_1
+lvs=lv_a06_distrep_1
+mountpoints=/mnt/brick_a06_distrep_1
+brick_dirs=/mnt/brick_a06_distrep_1/brick
+
+[volume]
+volname=volume_a06_distrep
+action=create
+brick_dirs=/mnt/brick_a06_distrep_1/brick
+transport=tcp
+replica=yes
+replica_count=2

--- a/gdeploy_config/dahorak/volume_a06_distrep_1brick.mount.conf
+++ b/gdeploy_config/dahorak/volume_a06_distrep_1brick.mount.conf
@@ -1,0 +1,14 @@
+# USM QE a06 configuration for GlusterFS
+#
+# This gdeploy config file assumes that we have:
+# * 1 client machine (GlusterFS client)
+
+[hosts]
+
+
+[clients]
+volname=volume_a06_distrep
+action=mount
+fstype=glusterfs
+client_mount_points=/mnt/volume_a06_distrep
+hosts=

--- a/gdeploy_config/dahorak/volume_a07_distrep_1brick.create.conf
+++ b/gdeploy_config/dahorak/volume_a07_distrep_1brick.create.conf
@@ -1,0 +1,27 @@
+# USM QE a07 configuration for GlusterFS
+#
+# This gdeploy config file assumes that we have:
+# * even number of Gluster storage servers
+# * 1 block device on each host (storage server) named /dev/vd{b,...}
+
+[hosts]
+
+[peer]
+action=probe
+ignore_peer_errors=no
+
+[backend-setup]
+devices=vdb
+vgs=vg_a07_distrep_1
+pools=pool_a07_distrep_1
+lvs=lv_a07_distrep_1
+mountpoints=/mnt/brick_a07_distrep_1
+brick_dirs=/mnt/brick_a07_distrep_1/brick
+
+[volume]
+volname=volume_a07_distrep
+action=create
+brick_dirs=/mnt/brick_a07_distrep_1/brick
+transport=tcp
+replica=yes
+replica_count=2

--- a/gdeploy_config/dahorak/volume_a07_distrep_1brick.mount.conf
+++ b/gdeploy_config/dahorak/volume_a07_distrep_1brick.mount.conf
@@ -1,0 +1,14 @@
+# USM QE a07 configuration for GlusterFS
+#
+# This gdeploy config file assumes that we have:
+# * 1 client machine (GlusterFS client)
+
+[hosts]
+
+
+[clients]
+volname=volume_a07_distrep
+action=mount
+fstype=glusterfs
+client_mount_points=/mnt/volume_a07_distrep
+hosts=

--- a/gdeploy_config/dahorak/volume_a08_distrep_1brick.create.conf
+++ b/gdeploy_config/dahorak/volume_a08_distrep_1brick.create.conf
@@ -1,0 +1,27 @@
+# USM QE a08 configuration for GlusterFS
+#
+# This gdeploy config file assumes that we have:
+# * even number of Gluster storage servers
+# * 1 block device on each host (storage server) named /dev/vd{b,...}
+
+[hosts]
+
+[peer]
+action=probe
+ignore_peer_errors=no
+
+[backend-setup]
+devices=vdb
+vgs=vg_a08_distrep_1
+pools=pool_a08_distrep_1
+lvs=lv_a08_distrep_1
+mountpoints=/mnt/brick_a08_distrep_1
+brick_dirs=/mnt/brick_a08_distrep_1/brick
+
+[volume]
+volname=volume_a08_distrep
+action=create
+brick_dirs=/mnt/brick_a08_distrep_1/brick
+transport=tcp
+replica=yes
+replica_count=2

--- a/gdeploy_config/dahorak/volume_a08_distrep_1brick.mount.conf
+++ b/gdeploy_config/dahorak/volume_a08_distrep_1brick.mount.conf
@@ -1,0 +1,14 @@
+# USM QE a08 configuration for GlusterFS
+#
+# This gdeploy config file assumes that we have:
+# * 1 client machine (GlusterFS client)
+
+[hosts]
+
+
+[clients]
+volname=volume_a08_distrep
+action=mount
+fstype=glusterfs
+client_mount_points=/mnt/volume_a08_distrep
+hosts=

--- a/gdeploy_config/dahorak/volume_a09_distrep_1brick.create.conf
+++ b/gdeploy_config/dahorak/volume_a09_distrep_1brick.create.conf
@@ -1,0 +1,27 @@
+# USM QE a09 configuration for GlusterFS
+#
+# This gdeploy config file assumes that we have:
+# * even number of Gluster storage servers
+# * 1 block device on each host (storage server) named /dev/vd{b,...}
+
+[hosts]
+
+[peer]
+action=probe
+ignore_peer_errors=no
+
+[backend-setup]
+devices=vdb
+vgs=vg_a09_distrep_1
+pools=pool_a09_distrep_1
+lvs=lv_a09_distrep_1
+mountpoints=/mnt/brick_a09_distrep_1
+brick_dirs=/mnt/brick_a09_distrep_1/brick
+
+[volume]
+volname=volume_a09_distrep
+action=create
+brick_dirs=/mnt/brick_a09_distrep_1/brick
+transport=tcp
+replica=yes
+replica_count=2

--- a/gdeploy_config/dahorak/volume_a09_distrep_1brick.mount.conf
+++ b/gdeploy_config/dahorak/volume_a09_distrep_1brick.mount.conf
@@ -1,0 +1,14 @@
+# USM QE a09 configuration for GlusterFS
+#
+# This gdeploy config file assumes that we have:
+# * 1 client machine (GlusterFS client)
+
+[hosts]
+
+
+[clients]
+volname=volume_a09_distrep
+action=mount
+fstype=glusterfs
+client_mount_points=/mnt/volume_a09_distrep
+hosts=

--- a/gdeploy_config/dahorak/volume_a10_distrep_1brick.create.conf
+++ b/gdeploy_config/dahorak/volume_a10_distrep_1brick.create.conf
@@ -1,0 +1,27 @@
+# USM QE a10 configuration for GlusterFS
+#
+# This gdeploy config file assumes that we have:
+# * even number of Gluster storage servers
+# * 1 block device on each host (storage server) named /dev/vd{b,...}
+
+[hosts]
+
+[peer]
+action=probe
+ignore_peer_errors=no
+
+[backend-setup]
+devices=vdb
+vgs=vg_a10_distrep_1
+pools=pool_a10_distrep_1
+lvs=lv_a10_distrep_1
+mountpoints=/mnt/brick_a10_distrep_1
+brick_dirs=/mnt/brick_a10_distrep_1/brick
+
+[volume]
+volname=volume_a10_distrep
+action=create
+brick_dirs=/mnt/brick_a10_distrep_1/brick
+transport=tcp
+replica=yes
+replica_count=2

--- a/gdeploy_config/dahorak/volume_a10_distrep_1brick.mount.conf
+++ b/gdeploy_config/dahorak/volume_a10_distrep_1brick.mount.conf
@@ -1,0 +1,14 @@
+# USM QE a10 configuration for GlusterFS
+#
+# This gdeploy config file assumes that we have:
+# * 1 client machine (GlusterFS client)
+
+[hosts]
+
+
+[clients]
+volname=volume_a10_distrep
+action=mount
+fstype=glusterfs
+client_mount_points=/mnt/volume_a10_distrep
+hosts=

--- a/gdeploy_config/dahorak/volume_a11_distrep_1brick.create.conf
+++ b/gdeploy_config/dahorak/volume_a11_distrep_1brick.create.conf
@@ -1,0 +1,27 @@
+# USM QE a11 configuration for GlusterFS
+#
+# This gdeploy config file assumes that we have:
+# * even number of Gluster storage servers
+# * 1 block device on each host (storage server) named /dev/vd{b,...}
+
+[hosts]
+
+[peer]
+action=probe
+ignore_peer_errors=no
+
+[backend-setup]
+devices=vdb
+vgs=vg_a11_distrep_1
+pools=pool_a11_distrep_1
+lvs=lv_a11_distrep_1
+mountpoints=/mnt/brick_a11_distrep_1
+brick_dirs=/mnt/brick_a11_distrep_1/brick
+
+[volume]
+volname=volume_a11_distrep
+action=create
+brick_dirs=/mnt/brick_a11_distrep_1/brick
+transport=tcp
+replica=yes
+replica_count=2

--- a/gdeploy_config/dahorak/volume_a11_distrep_1brick.mount.conf
+++ b/gdeploy_config/dahorak/volume_a11_distrep_1brick.mount.conf
@@ -1,0 +1,14 @@
+# USM QE a11 configuration for GlusterFS
+#
+# This gdeploy config file assumes that we have:
+# * 1 client machine (GlusterFS client)
+
+[hosts]
+
+
+[clients]
+volname=volume_a11_distrep
+action=mount
+fstype=glusterfs
+client_mount_points=/mnt/volume_a11_distrep
+hosts=

--- a/gdeploy_config/dahorak/volume_a12_distrep_1brick.create.conf
+++ b/gdeploy_config/dahorak/volume_a12_distrep_1brick.create.conf
@@ -1,0 +1,27 @@
+# USM QE a12 configuration for GlusterFS
+#
+# This gdeploy config file assumes that we have:
+# * even number of Gluster storage servers
+# * 1 block device on each host (storage server) named /dev/vd{b,...}
+
+[hosts]
+
+[peer]
+action=probe
+ignore_peer_errors=no
+
+[backend-setup]
+devices=vdb
+vgs=vg_a12_distrep_1
+pools=pool_a12_distrep_1
+lvs=lv_a12_distrep_1
+mountpoints=/mnt/brick_a12_distrep_1
+brick_dirs=/mnt/brick_a12_distrep_1/brick
+
+[volume]
+volname=volume_a12_distrep
+action=create
+brick_dirs=/mnt/brick_a12_distrep_1/brick
+transport=tcp
+replica=yes
+replica_count=2

--- a/gdeploy_config/dahorak/volume_a12_distrep_1brick.mount.conf
+++ b/gdeploy_config/dahorak/volume_a12_distrep_1brick.mount.conf
@@ -1,0 +1,14 @@
+# USM QE a12 configuration for GlusterFS
+#
+# This gdeploy config file assumes that we have:
+# * 1 client machine (GlusterFS client)
+
+[hosts]
+
+
+[clients]
+volname=volume_a12_distrep
+action=mount
+fstype=glusterfs
+client_mount_points=/mnt/volume_a12_distrep
+hosts=

--- a/gdeploy_config/dahorak/volume_a13_distrep_1brick.create.conf
+++ b/gdeploy_config/dahorak/volume_a13_distrep_1brick.create.conf
@@ -1,0 +1,27 @@
+# USM QE a13 configuration for GlusterFS
+#
+# This gdeploy config file assumes that we have:
+# * even number of Gluster storage servers
+# * 1 block device on each host (storage server) named /dev/vd{b,...}
+
+[hosts]
+
+[peer]
+action=probe
+ignore_peer_errors=no
+
+[backend-setup]
+devices=vdb
+vgs=vg_a13_distrep_1
+pools=pool_a13_distrep_1
+lvs=lv_a13_distrep_1
+mountpoints=/mnt/brick_a13_distrep_1
+brick_dirs=/mnt/brick_a13_distrep_1/brick
+
+[volume]
+volname=volume_a13_distrep
+action=create
+brick_dirs=/mnt/brick_a13_distrep_1/brick
+transport=tcp
+replica=yes
+replica_count=2

--- a/gdeploy_config/dahorak/volume_a13_distrep_1brick.mount.conf
+++ b/gdeploy_config/dahorak/volume_a13_distrep_1brick.mount.conf
@@ -1,0 +1,14 @@
+# USM QE a13 configuration for GlusterFS
+#
+# This gdeploy config file assumes that we have:
+# * 1 client machine (GlusterFS client)
+
+[hosts]
+
+
+[clients]
+volname=volume_a13_distrep
+action=mount
+fstype=glusterfs
+client_mount_points=/mnt/volume_a13_distrep
+hosts=

--- a/gdeploy_config/dahorak/volume_a14_distrep_1brick.create.conf
+++ b/gdeploy_config/dahorak/volume_a14_distrep_1brick.create.conf
@@ -1,0 +1,27 @@
+# USM QE a14 configuration for GlusterFS
+#
+# This gdeploy config file assumes that we have:
+# * even number of Gluster storage servers
+# * 1 block device on each host (storage server) named /dev/vd{b,...}
+
+[hosts]
+
+[peer]
+action=probe
+ignore_peer_errors=no
+
+[backend-setup]
+devices=vdb
+vgs=vg_a14_distrep_1
+pools=pool_a14_distrep_1
+lvs=lv_a14_distrep_1
+mountpoints=/mnt/brick_a14_distrep_1
+brick_dirs=/mnt/brick_a14_distrep_1/brick
+
+[volume]
+volname=volume_a14_distrep
+action=create
+brick_dirs=/mnt/brick_a14_distrep_1/brick
+transport=tcp
+replica=yes
+replica_count=2

--- a/gdeploy_config/dahorak/volume_a14_distrep_1brick.mount.conf
+++ b/gdeploy_config/dahorak/volume_a14_distrep_1brick.mount.conf
@@ -1,0 +1,14 @@
+# USM QE a14 configuration for GlusterFS
+#
+# This gdeploy config file assumes that we have:
+# * 1 client machine (GlusterFS client)
+
+[hosts]
+
+
+[clients]
+volname=volume_a14_distrep
+action=mount
+fstype=glusterfs
+client_mount_points=/mnt/volume_a14_distrep
+hosts=

--- a/gdeploy_config/dahorak/volume_a15_distrep_1brick.create.conf
+++ b/gdeploy_config/dahorak/volume_a15_distrep_1brick.create.conf
@@ -1,0 +1,27 @@
+# USM QE a15 configuration for GlusterFS
+#
+# This gdeploy config file assumes that we have:
+# * even number of Gluster storage servers
+# * 1 block device on each host (storage server) named /dev/vd{b,...}
+
+[hosts]
+
+[peer]
+action=probe
+ignore_peer_errors=no
+
+[backend-setup]
+devices=vdb
+vgs=vg_a15_distrep_1
+pools=pool_a15_distrep_1
+lvs=lv_a15_distrep_1
+mountpoints=/mnt/brick_a15_distrep_1
+brick_dirs=/mnt/brick_a15_distrep_1/brick
+
+[volume]
+volname=volume_a15_distrep
+action=create
+brick_dirs=/mnt/brick_a15_distrep_1/brick
+transport=tcp
+replica=yes
+replica_count=2

--- a/gdeploy_config/dahorak/volume_a15_distrep_1brick.mount.conf
+++ b/gdeploy_config/dahorak/volume_a15_distrep_1brick.mount.conf
@@ -1,0 +1,14 @@
+# USM QE a15 configuration for GlusterFS
+#
+# This gdeploy config file assumes that we have:
+# * 1 client machine (GlusterFS client)
+
+[hosts]
+
+
+[clients]
+volname=volume_a15_distrep
+action=mount
+fstype=glusterfs
+client_mount_points=/mnt/volume_a15_distrep
+hosts=

--- a/gdeploy_config/dahorak/volume_a16_distrep_1brick.create.conf
+++ b/gdeploy_config/dahorak/volume_a16_distrep_1brick.create.conf
@@ -1,0 +1,27 @@
+# USM QE a16 configuration for GlusterFS
+#
+# This gdeploy config file assumes that we have:
+# * even number of Gluster storage servers
+# * 1 block device on each host (storage server) named /dev/vd{b,...}
+
+[hosts]
+
+[peer]
+action=probe
+ignore_peer_errors=no
+
+[backend-setup]
+devices=vdb
+vgs=vg_a16_distrep_1
+pools=pool_a16_distrep_1
+lvs=lv_a16_distrep_1
+mountpoints=/mnt/brick_a16_distrep_1
+brick_dirs=/mnt/brick_a16_distrep_1/brick
+
+[volume]
+volname=volume_a16_distrep
+action=create
+brick_dirs=/mnt/brick_a16_distrep_1/brick
+transport=tcp
+replica=yes
+replica_count=2

--- a/gdeploy_config/dahorak/volume_a16_distrep_1brick.mount.conf
+++ b/gdeploy_config/dahorak/volume_a16_distrep_1brick.mount.conf
@@ -1,0 +1,14 @@
+# USM QE a16 configuration for GlusterFS
+#
+# This gdeploy config file assumes that we have:
+# * 1 client machine (GlusterFS client)
+
+[hosts]
+
+
+[clients]
+volname=volume_a16_distrep
+action=mount
+fstype=glusterfs
+client_mount_points=/mnt/volume_a16_distrep
+hosts=

--- a/gdeploy_config/dahorak/volume_a17_distrep_1brick.create.conf
+++ b/gdeploy_config/dahorak/volume_a17_distrep_1brick.create.conf
@@ -1,0 +1,27 @@
+# USM QE a17 configuration for GlusterFS
+#
+# This gdeploy config file assumes that we have:
+# * even number of Gluster storage servers
+# * 1 block device on each host (storage server) named /dev/vd{b,...}
+
+[hosts]
+
+[peer]
+action=probe
+ignore_peer_errors=no
+
+[backend-setup]
+devices=vdb
+vgs=vg_a17_distrep_1
+pools=pool_a17_distrep_1
+lvs=lv_a17_distrep_1
+mountpoints=/mnt/brick_a17_distrep_1
+brick_dirs=/mnt/brick_a17_distrep_1/brick
+
+[volume]
+volname=volume_a17_distrep
+action=create
+brick_dirs=/mnt/brick_a17_distrep_1/brick
+transport=tcp
+replica=yes
+replica_count=2

--- a/gdeploy_config/dahorak/volume_a17_distrep_1brick.mount.conf
+++ b/gdeploy_config/dahorak/volume_a17_distrep_1brick.mount.conf
@@ -1,0 +1,14 @@
+# USM QE a17 configuration for GlusterFS
+#
+# This gdeploy config file assumes that we have:
+# * 1 client machine (GlusterFS client)
+
+[hosts]
+
+
+[clients]
+volname=volume_a17_distrep
+action=mount
+fstype=glusterfs
+client_mount_points=/mnt/volume_a17_distrep
+hosts=

--- a/gdeploy_config/dahorak/volume_a18_distrep_1brick.create.conf
+++ b/gdeploy_config/dahorak/volume_a18_distrep_1brick.create.conf
@@ -1,0 +1,27 @@
+# USM QE a18 configuration for GlusterFS
+#
+# This gdeploy config file assumes that we have:
+# * even number of Gluster storage servers
+# * 1 block device on each host (storage server) named /dev/vd{b,...}
+
+[hosts]
+
+[peer]
+action=probe
+ignore_peer_errors=no
+
+[backend-setup]
+devices=vdb
+vgs=vg_a18_distrep_1
+pools=pool_a18_distrep_1
+lvs=lv_a18_distrep_1
+mountpoints=/mnt/brick_a18_distrep_1
+brick_dirs=/mnt/brick_a18_distrep_1/brick
+
+[volume]
+volname=volume_a18_distrep
+action=create
+brick_dirs=/mnt/brick_a18_distrep_1/brick
+transport=tcp
+replica=yes
+replica_count=2

--- a/gdeploy_config/dahorak/volume_a18_distrep_1brick.mount.conf
+++ b/gdeploy_config/dahorak/volume_a18_distrep_1brick.mount.conf
@@ -1,0 +1,14 @@
+# USM QE a18 configuration for GlusterFS
+#
+# This gdeploy config file assumes that we have:
+# * 1 client machine (GlusterFS client)
+
+[hosts]
+
+
+[clients]
+volname=volume_a18_distrep
+action=mount
+fstype=glusterfs
+client_mount_points=/mnt/volume_a18_distrep
+hosts=

--- a/gdeploy_config/dahorak/volume_a19_distrep_1brick.create.conf
+++ b/gdeploy_config/dahorak/volume_a19_distrep_1brick.create.conf
@@ -1,0 +1,27 @@
+# USM QE a19 configuration for GlusterFS
+#
+# This gdeploy config file assumes that we have:
+# * even number of Gluster storage servers
+# * 1 block device on each host (storage server) named /dev/vd{b,...}
+
+[hosts]
+
+[peer]
+action=probe
+ignore_peer_errors=no
+
+[backend-setup]
+devices=vdb
+vgs=vg_a19_distrep_1
+pools=pool_a19_distrep_1
+lvs=lv_a19_distrep_1
+mountpoints=/mnt/brick_a19_distrep_1
+brick_dirs=/mnt/brick_a19_distrep_1/brick
+
+[volume]
+volname=volume_a19_distrep
+action=create
+brick_dirs=/mnt/brick_a19_distrep_1/brick
+transport=tcp
+replica=yes
+replica_count=2

--- a/gdeploy_config/dahorak/volume_a19_distrep_1brick.mount.conf
+++ b/gdeploy_config/dahorak/volume_a19_distrep_1brick.mount.conf
@@ -1,0 +1,14 @@
+# USM QE a19 configuration for GlusterFS
+#
+# This gdeploy config file assumes that we have:
+# * 1 client machine (GlusterFS client)
+
+[hosts]
+
+
+[clients]
+volname=volume_a19_distrep
+action=mount
+fstype=glusterfs
+client_mount_points=/mnt/volume_a19_distrep
+hosts=

--- a/gdeploy_config/dahorak/volume_a20_distrep_1brick.create.conf
+++ b/gdeploy_config/dahorak/volume_a20_distrep_1brick.create.conf
@@ -1,0 +1,27 @@
+# USM QE a20 configuration for GlusterFS
+#
+# This gdeploy config file assumes that we have:
+# * even number of Gluster storage servers
+# * 1 block device on each host (storage server) named /dev/vd{b,...}
+
+[hosts]
+
+[peer]
+action=probe
+ignore_peer_errors=no
+
+[backend-setup]
+devices=vdb
+vgs=vg_a20_distrep_1
+pools=pool_a20_distrep_1
+lvs=lv_a20_distrep_1
+mountpoints=/mnt/brick_a20_distrep_1
+brick_dirs=/mnt/brick_a20_distrep_1/brick
+
+[volume]
+volname=volume_a20_distrep
+action=create
+brick_dirs=/mnt/brick_a20_distrep_1/brick
+transport=tcp
+replica=yes
+replica_count=2

--- a/gdeploy_config/dahorak/volume_a20_distrep_1brick.mount.conf
+++ b/gdeploy_config/dahorak/volume_a20_distrep_1brick.mount.conf
@@ -1,0 +1,14 @@
+# USM QE a20 configuration for GlusterFS
+#
+# This gdeploy config file assumes that we have:
+# * 1 client machine (GlusterFS client)
+
+[hosts]
+
+
+[clients]
+volname=volume_a20_distrep
+action=mount
+fstype=glusterfs
+client_mount_points=/mnt/volume_a20_distrep
+hosts=

--- a/gdeploy_config/dahorak/volume_b01_distrep_2bricks.create.conf
+++ b/gdeploy_config/dahorak/volume_b01_distrep_2bricks.create.conf
@@ -1,0 +1,27 @@
+# USM QE b01 configuration for GlusterFS
+#
+# This gdeploy config file assumes that we have:
+# * even number of Gluster storage servers
+# * 2 block devices on each host (storage server) named /dev/vd{b,c,...}
+
+[hosts]
+
+[peer]
+action=probe
+ignore_peer_errors=no
+
+[backend-setup]
+devices=vdb,vdc
+vgs=vg_b01_distrep_{1,2}
+pools=pool_b01_distrep_{1,2}
+lvs=lv_b01_distrep_{1,2}
+mountpoints=/mnt/brick_b01_distrep_{1,2}
+brick_dirs=/mnt/brick_b01_distrep_1/brick,/mnt/brick_b01_distrep_2/brick
+
+[volume]
+volname=volume_b01_distrep
+action=create
+brick_dirs=/mnt/brick_b01_distrep_1/brick,/mnt/brick_b01_distrep_2/brick
+transport=tcp
+replica=yes
+replica_count=2

--- a/gdeploy_config/dahorak/volume_b01_distrep_2bricks.mount.conf
+++ b/gdeploy_config/dahorak/volume_b01_distrep_2bricks.mount.conf
@@ -1,0 +1,14 @@
+# USM QE b01 configuration for GlusterFS
+#
+# This gdeploy config file assumes that we have:
+# * 1 client machine (GlusterFS client)
+
+[hosts]
+
+
+[clients]
+volname=volume_b01_distrep
+action=mount
+fstype=glusterfs
+client_mount_points=/mnt/volume_b01_distrep
+hosts=

--- a/gdeploy_config/dahorak/volume_b02_distrep_2bricks.create.conf
+++ b/gdeploy_config/dahorak/volume_b02_distrep_2bricks.create.conf
@@ -1,0 +1,27 @@
+# USM QE b02 configuration for GlusterFS
+#
+# This gdeploy config file assumes that we have:
+# * even number of Gluster storage servers
+# * 2 block devices on each host (storage server) named /dev/vd{b,c,...}
+
+[hosts]
+
+[peer]
+action=probe
+ignore_peer_errors=no
+
+[backend-setup]
+devices=vdb,vdc
+vgs=vg_b02_distrep_{1,2}
+pools=pool_b02_distrep_{1,2}
+lvs=lv_b02_distrep_{1,2}
+mountpoints=/mnt/brick_b02_distrep_{1,2}
+brick_dirs=/mnt/brick_b02_distrep_1/brick,/mnt/brick_b01_distrep_2/brick
+
+[volume]
+volname=volume_b02_distrep
+action=create
+brick_dirs=/mnt/brick_b02_distrep_1/brick,/mnt/brick_b01_distrep_2/brick
+transport=tcp
+replica=yes
+replica_count=2

--- a/gdeploy_config/dahorak/volume_b02_distrep_2bricks.mount.conf
+++ b/gdeploy_config/dahorak/volume_b02_distrep_2bricks.mount.conf
@@ -1,0 +1,14 @@
+# USM QE b02 configuration for GlusterFS
+#
+# This gdeploy config file assumes that we have:
+# * 1 client machine (GlusterFS client)
+
+[hosts]
+
+
+[clients]
+volname=volume_b02_distrep
+action=mount
+fstype=glusterfs
+client_mount_points=/mnt/volume_b02_distrep
+hosts=

--- a/gdeploy_config/dahorak/volume_b03_distrep_2bricks.create.conf
+++ b/gdeploy_config/dahorak/volume_b03_distrep_2bricks.create.conf
@@ -1,0 +1,27 @@
+# USM QE b03 configuration for GlusterFS
+#
+# This gdeploy config file assumes that we have:
+# * even number of Gluster storage servers
+# * 2 block devices on each host (storage server) named /dev/vd{b,c,...}
+
+[hosts]
+
+[peer]
+action=probe
+ignore_peer_errors=no
+
+[backend-setup]
+devices=vdb,vdc
+vgs=vg_b03_distrep_{1,2}
+pools=pool_b03_distrep_{1,2}
+lvs=lv_b03_distrep_{1,2}
+mountpoints=/mnt/brick_b03_distrep_{1,2}
+brick_dirs=/mnt/brick_b03_distrep_1/brick,/mnt/brick_b01_distrep_2/brick
+
+[volume]
+volname=volume_b03_distrep
+action=create
+brick_dirs=/mnt/brick_b03_distrep_1/brick,/mnt/brick_b01_distrep_2/brick
+transport=tcp
+replica=yes
+replica_count=2

--- a/gdeploy_config/dahorak/volume_b03_distrep_2bricks.mount.conf
+++ b/gdeploy_config/dahorak/volume_b03_distrep_2bricks.mount.conf
@@ -1,0 +1,14 @@
+# USM QE b03 configuration for GlusterFS
+#
+# This gdeploy config file assumes that we have:
+# * 1 client machine (GlusterFS client)
+
+[hosts]
+
+
+[clients]
+volname=volume_b03_distrep
+action=mount
+fstype=glusterfs
+client_mount_points=/mnt/volume_b03_distrep
+hosts=

--- a/gdeploy_config/dahorak/volume_b04_distrep_2bricks.create.conf
+++ b/gdeploy_config/dahorak/volume_b04_distrep_2bricks.create.conf
@@ -1,0 +1,27 @@
+# USM QE b04 configuration for GlusterFS
+#
+# This gdeploy config file assumes that we have:
+# * even number of Gluster storage servers
+# * 2 block devices on each host (storage server) named /dev/vd{b,c,...}
+
+[hosts]
+
+[peer]
+action=probe
+ignore_peer_errors=no
+
+[backend-setup]
+devices=vdb,vdc
+vgs=vg_b04_distrep_{1,2}
+pools=pool_b04_distrep_{1,2}
+lvs=lv_b04_distrep_{1,2}
+mountpoints=/mnt/brick_b04_distrep_{1,2}
+brick_dirs=/mnt/brick_b04_distrep_1/brick,/mnt/brick_b01_distrep_2/brick
+
+[volume]
+volname=volume_b04_distrep
+action=create
+brick_dirs=/mnt/brick_b04_distrep_1/brick,/mnt/brick_b01_distrep_2/brick
+transport=tcp
+replica=yes
+replica_count=2

--- a/gdeploy_config/dahorak/volume_b04_distrep_2bricks.mount.conf
+++ b/gdeploy_config/dahorak/volume_b04_distrep_2bricks.mount.conf
@@ -1,0 +1,14 @@
+# USM QE b04 configuration for GlusterFS
+#
+# This gdeploy config file assumes that we have:
+# * 1 client machine (GlusterFS client)
+
+[hosts]
+
+
+[clients]
+volname=volume_b04_distrep
+action=mount
+fstype=glusterfs
+client_mount_points=/mnt/volume_b04_distrep
+hosts=

--- a/gdeploy_config/dahorak/volume_b05_distrep_2bricks.create.conf
+++ b/gdeploy_config/dahorak/volume_b05_distrep_2bricks.create.conf
@@ -1,0 +1,27 @@
+# USM QE b05 configuration for GlusterFS
+#
+# This gdeploy config file assumes that we have:
+# * even number of Gluster storage servers
+# * 2 block devices on each host (storage server) named /dev/vd{b,c,...}
+
+[hosts]
+
+[peer]
+action=probe
+ignore_peer_errors=no
+
+[backend-setup]
+devices=vdb,vdc
+vgs=vg_b05_distrep_{1,2}
+pools=pool_b05_distrep_{1,2}
+lvs=lv_b05_distrep_{1,2}
+mountpoints=/mnt/brick_b05_distrep_{1,2}
+brick_dirs=/mnt/brick_b05_distrep_1/brick,/mnt/brick_b01_distrep_2/brick
+
+[volume]
+volname=volume_b05_distrep
+action=create
+brick_dirs=/mnt/brick_b05_distrep_1/brick,/mnt/brick_b01_distrep_2/brick
+transport=tcp
+replica=yes
+replica_count=2

--- a/gdeploy_config/dahorak/volume_b05_distrep_2bricks.mount.conf
+++ b/gdeploy_config/dahorak/volume_b05_distrep_2bricks.mount.conf
@@ -1,0 +1,14 @@
+# USM QE b05 configuration for GlusterFS
+#
+# This gdeploy config file assumes that we have:
+# * 1 client machine (GlusterFS client)
+
+[hosts]
+
+
+[clients]
+volname=volume_b05_distrep
+action=mount
+fstype=glusterfs
+client_mount_points=/mnt/volume_b05_distrep
+hosts=

--- a/gdeploy_config/dahorak/volume_b06_distrep_2bricks.create.conf
+++ b/gdeploy_config/dahorak/volume_b06_distrep_2bricks.create.conf
@@ -1,0 +1,27 @@
+# USM QE b06 configuration for GlusterFS
+#
+# This gdeploy config file assumes that we have:
+# * even number of Gluster storage servers
+# * 2 block devices on each host (storage server) named /dev/vd{b,c,...}
+
+[hosts]
+
+[peer]
+action=probe
+ignore_peer_errors=no
+
+[backend-setup]
+devices=vdb,vdc
+vgs=vg_b06_distrep_{1,2}
+pools=pool_b06_distrep_{1,2}
+lvs=lv_b06_distrep_{1,2}
+mountpoints=/mnt/brick_b06_distrep_{1,2}
+brick_dirs=/mnt/brick_b06_distrep_1/brick,/mnt/brick_b01_distrep_2/brick
+
+[volume]
+volname=volume_b06_distrep
+action=create
+brick_dirs=/mnt/brick_b06_distrep_1/brick,/mnt/brick_b01_distrep_2/brick
+transport=tcp
+replica=yes
+replica_count=2

--- a/gdeploy_config/dahorak/volume_b06_distrep_2bricks.mount.conf
+++ b/gdeploy_config/dahorak/volume_b06_distrep_2bricks.mount.conf
@@ -1,0 +1,14 @@
+# USM QE b06 configuration for GlusterFS
+#
+# This gdeploy config file assumes that we have:
+# * 1 client machine (GlusterFS client)
+
+[hosts]
+
+
+[clients]
+volname=volume_b06_distrep
+action=mount
+fstype=glusterfs
+client_mount_points=/mnt/volume_b06_distrep
+hosts=

--- a/gdeploy_config/dahorak/volume_b07_distrep_2bricks.create.conf
+++ b/gdeploy_config/dahorak/volume_b07_distrep_2bricks.create.conf
@@ -1,0 +1,27 @@
+# USM QE b07 configuration for GlusterFS
+#
+# This gdeploy config file assumes that we have:
+# * even number of Gluster storage servers
+# * 2 block devices on each host (storage server) named /dev/vd{b,c,...}
+
+[hosts]
+
+[peer]
+action=probe
+ignore_peer_errors=no
+
+[backend-setup]
+devices=vdb,vdc
+vgs=vg_b07_distrep_{1,2}
+pools=pool_b07_distrep_{1,2}
+lvs=lv_b07_distrep_{1,2}
+mountpoints=/mnt/brick_b07_distrep_{1,2}
+brick_dirs=/mnt/brick_b07_distrep_1/brick,/mnt/brick_b01_distrep_2/brick
+
+[volume]
+volname=volume_b07_distrep
+action=create
+brick_dirs=/mnt/brick_b07_distrep_1/brick,/mnt/brick_b01_distrep_2/brick
+transport=tcp
+replica=yes
+replica_count=2

--- a/gdeploy_config/dahorak/volume_b07_distrep_2bricks.mount.conf
+++ b/gdeploy_config/dahorak/volume_b07_distrep_2bricks.mount.conf
@@ -1,0 +1,14 @@
+# USM QE b07 configuration for GlusterFS
+#
+# This gdeploy config file assumes that we have:
+# * 1 client machine (GlusterFS client)
+
+[hosts]
+
+
+[clients]
+volname=volume_b07_distrep
+action=mount
+fstype=glusterfs
+client_mount_points=/mnt/volume_b07_distrep
+hosts=

--- a/gdeploy_config/dahorak/volume_b08_distrep_2bricks.create.conf
+++ b/gdeploy_config/dahorak/volume_b08_distrep_2bricks.create.conf
@@ -1,0 +1,27 @@
+# USM QE b08 configuration for GlusterFS
+#
+# This gdeploy config file assumes that we have:
+# * even number of Gluster storage servers
+# * 2 block devices on each host (storage server) named /dev/vd{b,c,...}
+
+[hosts]
+
+[peer]
+action=probe
+ignore_peer_errors=no
+
+[backend-setup]
+devices=vdb,vdc
+vgs=vg_b08_distrep_{1,2}
+pools=pool_b08_distrep_{1,2}
+lvs=lv_b08_distrep_{1,2}
+mountpoints=/mnt/brick_b08_distrep_{1,2}
+brick_dirs=/mnt/brick_b08_distrep_1/brick,/mnt/brick_b01_distrep_2/brick
+
+[volume]
+volname=volume_b08_distrep
+action=create
+brick_dirs=/mnt/brick_b08_distrep_1/brick,/mnt/brick_b01_distrep_2/brick
+transport=tcp
+replica=yes
+replica_count=2

--- a/gdeploy_config/dahorak/volume_b08_distrep_2bricks.mount.conf
+++ b/gdeploy_config/dahorak/volume_b08_distrep_2bricks.mount.conf
@@ -1,0 +1,14 @@
+# USM QE b08 configuration for GlusterFS
+#
+# This gdeploy config file assumes that we have:
+# * 1 client machine (GlusterFS client)
+
+[hosts]
+
+
+[clients]
+volname=volume_b08_distrep
+action=mount
+fstype=glusterfs
+client_mount_points=/mnt/volume_b08_distrep
+hosts=

--- a/gdeploy_config/dahorak/volume_b09_distrep_2bricks.create.conf
+++ b/gdeploy_config/dahorak/volume_b09_distrep_2bricks.create.conf
@@ -1,0 +1,27 @@
+# USM QE b09 configuration for GlusterFS
+#
+# This gdeploy config file assumes that we have:
+# * even number of Gluster storage servers
+# * 2 block devices on each host (storage server) named /dev/vd{b,c,...}
+
+[hosts]
+
+[peer]
+action=probe
+ignore_peer_errors=no
+
+[backend-setup]
+devices=vdb,vdc
+vgs=vg_b09_distrep_{1,2}
+pools=pool_b09_distrep_{1,2}
+lvs=lv_b09_distrep_{1,2}
+mountpoints=/mnt/brick_b09_distrep_{1,2}
+brick_dirs=/mnt/brick_b09_distrep_1/brick,/mnt/brick_b01_distrep_2/brick
+
+[volume]
+volname=volume_b09_distrep
+action=create
+brick_dirs=/mnt/brick_b09_distrep_1/brick,/mnt/brick_b01_distrep_2/brick
+transport=tcp
+replica=yes
+replica_count=2

--- a/gdeploy_config/dahorak/volume_b09_distrep_2bricks.mount.conf
+++ b/gdeploy_config/dahorak/volume_b09_distrep_2bricks.mount.conf
@@ -1,0 +1,14 @@
+# USM QE b09 configuration for GlusterFS
+#
+# This gdeploy config file assumes that we have:
+# * 1 client machine (GlusterFS client)
+
+[hosts]
+
+
+[clients]
+volname=volume_b09_distrep
+action=mount
+fstype=glusterfs
+client_mount_points=/mnt/volume_b09_distrep
+hosts=

--- a/gdeploy_config/dahorak/volume_b10_distrep_2bricks.create.conf
+++ b/gdeploy_config/dahorak/volume_b10_distrep_2bricks.create.conf
@@ -1,0 +1,27 @@
+# USM QE b10 configuration for GlusterFS
+#
+# This gdeploy config file assumes that we have:
+# * even number of Gluster storage servers
+# * 2 block devices on each host (storage server) named /dev/vd{b,c,...}
+
+[hosts]
+
+[peer]
+action=probe
+ignore_peer_errors=no
+
+[backend-setup]
+devices=vdb,vdc
+vgs=vg_b10_distrep_{1,2}
+pools=pool_b10_distrep_{1,2}
+lvs=lv_b10_distrep_{1,2}
+mountpoints=/mnt/brick_b10_distrep_{1,2}
+brick_dirs=/mnt/brick_b10_distrep_1/brick,/mnt/brick_b01_distrep_2/brick
+
+[volume]
+volname=volume_b10_distrep
+action=create
+brick_dirs=/mnt/brick_b10_distrep_1/brick,/mnt/brick_b01_distrep_2/brick
+transport=tcp
+replica=yes
+replica_count=2

--- a/gdeploy_config/dahorak/volume_b10_distrep_2bricks.mount.conf
+++ b/gdeploy_config/dahorak/volume_b10_distrep_2bricks.mount.conf
@@ -1,0 +1,14 @@
+# USM QE b10 configuration for GlusterFS
+#
+# This gdeploy config file assumes that we have:
+# * 1 client machine (GlusterFS client)
+
+[hosts]
+
+
+[clients]
+volname=volume_b10_distrep
+action=mount
+fstype=glusterfs
+client_mount_points=/mnt/volume_b10_distrep
+hosts=


### PR DESCRIPTION
It would be useful, if we will be able to create higher number of volumes.

As of now, there is no other possibility, than create separated gdeploy config files for each volume.
So I've prepared bunch of configurations for two volume configurations (all volumes are Distributed-Replicated - the difference is number of used bricks peer one node).

I've saved them into `dahorak` sub-directory, but if you have idea for better name, please suggest.