### PR TITLE
add new Gluster CentOS repos

### DIFF
--- a/roles/gluster-centos-repo/vars/main.yml
+++ b/roles/gluster-centos-repo/vars/main.yml
@@ -3,6 +3,15 @@ gluster_centos_repos:
     nightly:
         description: "Gluster nightly builds from CentOS Storage SIG"
         baseurl: "http://artifacts.ci.centos.org/gluster/nightly/master/7/x86_64/"
+    4-1:
+        description: "Gluster 4.1 from CentOS Storage SIG"
+        baseurl: "http://buildlogs.centos.org/centos/7/storage/x86_64/gluster-4.1/"
+    4-0:
+        description: "Gluster 4.0 from CentOS Storage SIG"
+        baseurl: "http://buildlogs.centos.org/centos/7/storage/x86_64/gluster-4.0/"
+    3-13:
+        description: "Gluster 3.13 from CentOS Storage SIG"
+        baseurl: "http://buildlogs.centos.org/centos/7/storage/x86_64/gluster-3.13/"
     3-12:
         description: "Gluster 3.12 from CentOS Storage SIG"
         baseurl: "http://buildlogs.centos.org/centos/7/storage/x86_64/gluster-3.12/"


### PR DESCRIPTION
Add Gluster CentOS repos for versions 3.13, 4.0 and 4.1.