### PR TITLE
WORKAROUND: restart tendrl-node-agent service

### DIFF
--- a/ci_default_post_tendrl.yml
+++ b/ci_default_post_tendrl.yml
@@ -22,3 +22,10 @@
       yum:
         name: ansible
         state: latest
+      register: ansible_update_status
+
+    - name: "WORKAROUND: (update ansible) restart tendrl-node-agent"
+      service:
+        name: "tendrl-node-agent"
+        state: restarted
+      when: ansible_update_status.changed


### PR DESCRIPTION
- when *ansible* is updated, restart related *tendrl-node-agent* service
- related to #202