### PR TITLE
add gdeploy config for fips mode

### DIFF
--- a/gdeploy_config/volume_alpha_distrep_6x2.fips.conf
+++ b/gdeploy_config/volume_alpha_distrep_6x2.fips.conf
@@ -1,0 +1,7 @@
+[hosts]
+
+[volume]
+volname=volume_alpha_distrep_6x2
+action=set
+key=fips-mode-rchecksum
+value=enable

--- a/gdeploy_config/volume_beta_arbiter_2_plus_1x2.fips.conf
+++ b/gdeploy_config/volume_beta_arbiter_2_plus_1x2.fips.conf
@@ -1,0 +1,7 @@
+[hosts]
+
+[volume]
+volname=volume_beta_arbiter_2_plus_1x2
+action=set
+key=fips-mode-rchecksum
+value=enable

--- a/gdeploy_config/volume_gama_disperse_4_plus_2x2.fips.conf
+++ b/gdeploy_config/volume_gama_disperse_4_plus_2x2.fips.conf
@@ -1,0 +1,7 @@
+[hosts]
+
+[volume]
+volname=volume_gama_disperse_4_plus_2x2
+action=set
+key=fips-mode-rchecksum
+value=enable


### PR DESCRIPTION
This configures gluster volumes to use `fips-mode-rchecksum`.

Validation:

```
# gluster volume get volume_beta_arbiter_2_plus_1x2 fips-mode-rchecksum
Option                                  Value                                   
------                                  -----                                   
storage.fips-mode-rchecksum             enable
```