### PR TITLE
reference bugzilla for fips gluster option

### DIFF
--- a/gdeploy_config/volume_alpha_distrep_6x2.fips.conf
+++ b/gdeploy_config/volume_alpha_distrep_6x2.fips.conf
@@ -1,3 +1,5 @@
+# Based on this bugzilla comment:
+# https://bugzilla.redhat.com/show_bug.cgi?id=1634020#c7
 [hosts]
 
 [volume]

--- a/gdeploy_config/volume_beta_arbiter_2_plus_1x2.fips.conf
+++ b/gdeploy_config/volume_beta_arbiter_2_plus_1x2.fips.conf
@@ -1,3 +1,5 @@
+# Based on this bugzilla comment:
+# https://bugzilla.redhat.com/show_bug.cgi?id=1634020#c7
 [hosts]
 
 [volume]

--- a/gdeploy_config/volume_gama_disperse_4_plus_2x2.fips.conf
+++ b/gdeploy_config/volume_gama_disperse_4_plus_2x2.fips.conf
@@ -1,3 +1,5 @@
+# Based on this bugzilla comment:
+# https://bugzilla.redhat.com/show_bug.cgi?id=1634020#c7
 [hosts]
 
 [volume]


### PR DESCRIPTION
Right now, this bugzilla is the only reference for `fips-mode-rchecksum` option.