### PR TITLE
test setup fips: don't enable fips on client

### DIFF
--- a/test_setup.fips.yml
+++ b/test_setup.fips.yml
@@ -3,7 +3,7 @@
 # are listed here: https://access.redhat.com/solutions/137833
 # See also:
 # https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/security_guide/chap-federal_standards_and_regulations
-- hosts: usm_nodes:usm_client
+- hosts: usm_nodes
   remote_user: root
   tasks:
     - name: Install dracut-fips


### PR DESCRIPTION
This is done to workaround know issue with snmp alerting and FIPS mode,
see:

* https://bugzilla.redhat.com/show_bug.cgi?id=1640638
* https://bugzilla.redhat.com/show_bug.cgi?id=1513066