### PR TITLE
add epel as part of pre setup procedure

### DIFF
--- a/ci_default_pre_setup.yml
+++ b/ci_default_pre_setup.yml
@@ -11,3 +11,8 @@
   when: configure_fips|default(false)|bool
 
 - include: gluster.yml
+
+- hosts: tendrl_server
+  remote_user: root
+  roles:
+    - { role: epel, epel_enabled: 1 }


### PR DESCRIPTION
- epel is now required to be enabled before tendrl-ansible installation
  on tendrl_server
- fixing https://github.com/Tendrl/commons/pull/1055#issuecomment-420184234
- this apply only for upstream (CentOS) installation