### PR TITLE
qe-server: install chromium for web tests

### DIFF
--- a/roles/qe-server/tasks/main.yml
+++ b/roles/qe-server/tasks/main.yml
@@ -77,6 +77,7 @@
     - xorg-x11-server-Xvfb
     - x11vnc
     - firefox
+    - chromium
 
 - name: Install systemd service unit file
   copy:


### PR DESCRIPTION
We will have both firefox and chromium available on qe server.

Chromium was added because initial version of our tarreto based web
tests requires chromium, see:
https://github.com/usmqe/usmqe-tests/pull/217

Chromium is installed from EPEL 7.