### PR TITLE
qe_server: add possibility to skip ssl config

### DIFF
--- a/qe_server.yml
+++ b/qe_server.yml
@@ -10,10 +10,12 @@
    - { role: epel, epel_enabled: 1 }
    - rh-python36
    - tendrl-ansible.gluster-gdeploy-copr
-   - qe-ssl-ca
+   - role: qe-ssl-ca
+     when: skip_ssl_configuration is not defined
    - role: qe-ssl-cert
      ssl_key_perm: "0644"
      ssl_cert_name: "qeserver"
+     when: skip_ssl_configuration is not defined
    - qe-server
 
 - name: Prepare test environment of usmqe user

--- a/qe_server_jenkins.yml
+++ b/qe_server_jenkins.yml
@@ -11,11 +11,9 @@
    - rh-python36
    - tendrl-ansible.gluster-gdeploy-copr
    - role: qe-ssl-ca
-     when: ca_usmqe_cert_url is defined
    - role: qe-ssl-cert
      ssl_key_perm: "0644"
      ssl_cert_name: "qeserver"
-     when: ca_usmqe_cert_url is defined
    - qe-server
   tasks:
    - name: Add jenkins user into usmqe group


### PR DESCRIPTION
* skip ssl configuration if skip_ssl_configuration is defined
  (used in CentOS CI)
* remove previously added "skip" condition in qe_server_jenkins.yml
  playbookk