### PR TITLE
increase resolution of Xvfb for web tests

### DIFF
--- a/roles/qe-server/files/Xvfb.service
+++ b/roles/qe-server/files/Xvfb.service
@@ -3,7 +3,7 @@ Description=Xvfb virtual framebuffer X server for X Version 11
 After=network.target
 
 [Service]
-ExecStart=/usr/bin/Xvfb :0 -screen 0 1280x1024x16 -noreset
+ExecStart=/usr/bin/Xvfb :0 -screen 0 1920x1080x16 -noreset
 
 [Install]
 WantedBy=multi-user.target

--- a/roles/qe-server/handlers/main.yml
+++ b/roles/qe-server/handlers/main.yml
@@ -1,0 +1,12 @@
+---
+- name: restart Xvfb
+  service:
+    name: Xvfb
+    state: restarted
+    daemon-reload: yes
+
+- name: restart x11vnc
+  service:
+    name: x11vnc
+    state: restarted
+    daemon-reload: yes

--- a/roles/qe-server/tasks/main.yml
+++ b/roles/qe-server/tasks/main.yml
@@ -91,6 +91,9 @@
   with_items:
     - Xvfb.service
     - x11vnc.service
+  notify:
+    - restart Xvfb
+    - restart x11vnc
 
 - name: Enable both services
   service:


### PR DESCRIPTION
This is necessary for usmqe_tests.ui.test_host_ui.test_host_bricks to
navigate in web ui (volume name, which is quite long, was so short that
it can't be recognized in the original resolution).