### PR TITLE
ensure that generated ssl certs will use sha256 algorithm instead of sha1

### DIFF
--- a/roles/qe-ssl-cert/files/ssl_cert.sh
+++ b/roles/qe-ssl-cert/files/ssl_cert.sh
@@ -49,7 +49,7 @@ function mrg_ssl_create_key() {
   #echo -e ".\n.\n.\n.\n.\n${CERT_CN}\n.\n.\n.\n" \
   #| openssl req -new -nodes -key ${CERT_NAME}.key  -out ${CERT_NAME}.csr
   openssl req -new -nodes -key ${CERT_NAME}.key -out ${CERT_NAME}.csr -config /tmp/openssl.cnf \
-    -subj "/C=CZ/ST=CZ/L=Brno/O=Red Hat/OU=USM - QE/CN=${CERT_CN}"
+    -subj "/C=CZ/ST=CZ/L=Brno/O=Red Hat/OU=USM - QE/CN=${CERT_CN}" -sha256
   [ $? -ne 0 ] && err=$((${err} + 1))
 }
 


### PR DESCRIPTION
* ensure that generated ssl certs will use sha256 algorithm  instead of sha1
* related change on the *ooo* server is in `/etc/pki/tls/openssl.cnf`: set `default_md` to `sha256` (already in place)