### PR TITLE
Tweak setup playbooks to work with https enabled Tendrl API

### DIFF
--- a/configure_admin_email_notifications.yml
+++ b/configure_admin_email_notifications.yml
@@ -17,8 +17,7 @@
   vars:
     tendrl_user: "admin"
     tendrl_password: "adminuser"
-    tendrl_api_url_protocol: "http"
-    tendrl_api_url: "{{ tendrl_api_url_protocol }}://{{ inventory_hostname }}/api/1.0"
+    tendrl_api_url: "{{ tendrl_api_url_protocol | default('http') }}://{{ inventory_hostname }}/api/1.0"
 
   pre_tasks:
     - name: Check that 'recipient_email' variable is defined properly

--- a/configure_admin_email_notifications.yml
+++ b/configure_admin_email_notifications.yml
@@ -26,8 +26,13 @@
           - recipient_email is defined
 
   tasks:
+
+    - debug:
+        var: tendrl_api_url
+
     - name: Login into Tendrl
-      uri:
+      local_action:
+        module: uri
         url: "{{ tendrl_api_url }}/login"
         method: POST
         body: {"username":"{{ tendrl_user }}", "password":"{{ tendrl_password }}"}
@@ -35,7 +40,8 @@
       register: login
 
     - name: Configure admin user
-      uri:
+      local_action:
+        module: uri
         url: "{{ tendrl_api_url }}/users/admin"
         method: PUT
         body: {"name":"Admin", "username":"admin", "email":"{{ recipient_email }}", "role":"admin", "email_notifications":true}
@@ -44,7 +50,8 @@
           Authorization: Bearer {{ login.json.access_token }}
 
     - name: Logout
-      uri:
+      local_action:
+        module: uri
         url: "{{ tendrl_api_url }}/logout"
         method: DELETE
         return_content: yes

--- a/test_setup.alerts_logger.yml
+++ b/test_setup.alerts_logger.yml
@@ -11,9 +11,17 @@
   vars:
     tendrl_user: "admin"
     tendrl_password: "adminuser"
-    tendrl_ssl: "false"
 
   tasks:
+
+    - set_fact:
+        tendrl_ssl: "{{ 'true' if tendrl_api_url_protocol == 'https' else 'false' }}"
+      when: tendrl_api_url_protocol is defined
+
+    - set_fact:
+        tendrl_ssl: "false"
+      when: tendrl_api_url_protocol is undefined
+
     - name: Create alerts_logger python script
       copy:
         dest: "/usr/local/bin/usmqe_alerts_logger.py"

--- a/test_setup.smtp.yml
+++ b/test_setup.smtp.yml
@@ -84,6 +84,9 @@
 
   tasks:
 
+    - debug:
+        var: tendrl_api_url
+
     # this task comes from tendl-ansible
     - name: Setup email notifications in email.conf.yaml of tendrl-notifier
       lineinfile:
@@ -101,7 +104,8 @@
         - restart tendrl-notifier
 
     - name: Login into Tendrl via API
-      uri:
+      local_action:
+        module: uri
         url: "{{ tendrl_api_url }}/login"
         method: POST
         body: {"username":"{{ tendrl_user }}", "password":"{{ tendrl_password }}"}
@@ -109,7 +113,8 @@
       register: login
 
     - name: Enable and configure email notifications for admin user via API
-      uri:
+      local_action:
+        module: uri
         url: "{{ tendrl_api_url }}/users/admin"
         method: PUT
         body: {"name":"Admin", "username":"admin", "email":"{{ tendrl_admin_recipient_email }}", "role":"admin", "email_notifications":true}
@@ -118,7 +123,8 @@
           Authorization: Bearer {{ login.json.access_token }}
 
     - name: Logout via API
-      uri:
+      local_action:
+        module: uri
         url: "{{ tendrl_api_url }}/logout"
         method: DELETE
         return_content: yes

--- a/test_setup.smtp.yml
+++ b/test_setup.smtp.yml
@@ -72,9 +72,7 @@
     # TODO: load admin and password from somewhere?
     tendrl_user: "admin"
     tendrl_password: "adminuser"
-    # note: we don't support https or other api versions so far
-    tendrl_api_url_protocol: "http"
-    tendrl_api_url: "{{ tendrl_api_url_protocol }}://{{ inventory_hostname }}/api/1.0"
+    tendrl_api_url: "{{ tendrl_api_url_protocol | default('http') }}://{{ inventory_hostname }}/api/1.0"
     # notifier sends email alerts (for tendrl admin) to this email address
     tendrl_admin_recipient_email: "root@{{ groups['usm_client'][0] }}"
     # notifier sends email alerts from this email address

--- a/test_teardown.smtp.yml
+++ b/test_teardown.smtp.yml
@@ -15,6 +15,9 @@
 
   tasks:
 
+    - debug:
+        var: tendrl_api_url
+
     # this task comes from tendl-ansible,
     # using default values from tendrl-notifier rpm package
     - name: Reset email notifications in email.conf.yaml of tendrl-notifier
@@ -33,7 +36,8 @@
         - restart tendrl-notifier
 
     - name: Login into Tendrl via API
-      uri:
+      local_action:
+        module: uri
         url: "{{ tendrl_api_url }}/login"
         method: POST
         body: {"username":"{{ tendrl_user }}", "password":"{{ tendrl_password }}"}
@@ -41,7 +45,8 @@
       register: login
 
     - name: Disable and unconfigure email notifications for admin user via API
-      uri:
+      local_action:
+        module: uri
         url: "{{ tendrl_api_url }}/users/admin"
         method: PUT
         body: {"name":"Admin", "username":"admin", "email":"admin@example.com", "role":"admin", "email_notifications":false}
@@ -50,7 +55,8 @@
           Authorization: Bearer {{ login.json.access_token }}
 
     - name: Logout via API
-      uri:
+      local_action:
+        module: uri
         url: "{{ tendrl_api_url }}/logout"
         method: DELETE
         return_content: yes

--- a/test_teardown.smtp.yml
+++ b/test_teardown.smtp.yml
@@ -11,9 +11,7 @@
     # TODO: load admin and password from somewhere?
     tendrl_user: "admin"
     tendrl_password: "adminuser"
-    # note: we don't support https or other api versions so far
-    tendrl_api_url_protocol: "http"
-    tendrl_api_url: "{{ tendrl_api_url_protocol }}://{{ inventory_hostname }}/api/1.0"
+    tendrl_api_url: "{{ tendrl_api_url_protocol | default('http') }}://{{ inventory_hostname }}/api/1.0"
 
   tasks:
 


### PR DESCRIPTION
This expects that one specifies `tendrl_api_url_protocol: https` in the inventory file when https is enabled.

It is necessary for https://github.com/usmqe/usmqe-tests/pull/231