### PR TITLE
test setup: tendrl nodeagent stopped on one node

### DIFF
--- a/test_setup.tendrl_nodeagent_stopped_on_one_node.yml
+++ b/test_setup.tendrl_nodeagent_stopped_on_one_node.yml
@@ -1,0 +1,15 @@
+---
+# =============================================================
+#  QE configuration for stopping tendrl node agent on one node
+# =============================================================
+#
+# This playbook serves as a setup for negative test cases, such as import
+# with cluster in an invalid state.
+
+- hosts: gluster_servers[0]
+  remote_user: root
+  tasks:
+    - name: Stop tendrl-node-agent
+      service:
+        name: tendrl-node-agent
+        state: stopped

--- a/test_teardown.tendrl_nodeagent_stopped_on_one_node.yml
+++ b/test_teardown.tendrl_nodeagent_stopped_on_one_node.yml
@@ -1,0 +1,15 @@
+---
+# =============================================================
+#  QE configuration for stopping tendrl node agent on one node
+# =============================================================
+#
+# This playbook serves as a teardown for negative test cases, such as import
+# with cluster in an invalid state.
+
+- hosts: gluster_servers
+  remote_user: root
+  tasks:
+    - name: Start tendrl-node-agent
+      service:
+        name: tendrl-node-agent
+        state: started


### PR DESCRIPTION
These playbooks serve as a setup/teardown for negative test cases, such as import with cluster in an invalid state.